### PR TITLE
fix: Qdrant missing keyword indexes on passages and style_profiles (sentry MCP-WRITING-5, MCP-WRITING-1)

### DIFF
--- a/src/tools/collections.py
+++ b/src/tools/collections.py
@@ -40,6 +40,15 @@ def _safe_client_id(client_id: str) -> str:
     return re.sub(r"[^a-zA-Z0-9_-]", "_", client_id)
 
 
+# Keyword payload indexes required by the tools that filter on them. Qdrant
+# returns HTTP 400 ("Index required but not found") when a filter hits an
+# unindexed field, so we create them eagerly on first use per client_id.
+_PAYLOAD_KEYWORD_INDEXES: dict[str, tuple[str, ...]] = {
+    "passages": ("entry_type", "doc_type", "language", "domain", "rubric_section"),
+    "style_profiles": ("name", "channel"),
+}
+
+
 def get_core_collection_names() -> dict:
     """Return names for shared/core collections (not user-scoped).
 
@@ -138,35 +147,56 @@ def setup_collections(client_id: str = "default") -> dict:
 _initialized_clients: set = set()
 
 
+def _ensure_keyword_index(qc, collection: str, field: str) -> None:
+    """Create a keyword payload index on *field*, tolerating 409 already-exists."""
+    from qdrant_client.models import PayloadSchemaType
+
+    try:
+        qc.create_payload_index(
+            collection_name=collection,
+            field_name=field,
+            field_schema=PayloadSchemaType.KEYWORD,
+        )
+        logger.info("Created keyword payload index", collection=collection, field=field)
+    except Exception as e:
+        msg = str(e).lower()
+        if "already exists" in msg or "409" in msg:
+            return
+        logger.warning(
+            "Could not create payload index",
+            collection=collection,
+            field=field,
+            error=str(e),
+        )
+
+
 def ensure_user_collections_once(client_id: str = "default") -> None:
     """Create per-user Qdrant collections on first call per process per client_id.
 
     Idempotent: subsequent calls for the same client_id are no-ops.
-    Also ensures the ``entry_type`` payload index exists on the passages collection
-    so that ``score_semantic_ai_likelihood`` filters work without a 400 error.
+    Also ensures the keyword payload indexes listed in ``_PAYLOAD_KEYWORD_INDEXES``
+    exist so that filter-based queries do not fail with HTTP 400.
     """
     if client_id in _initialized_clients:
         return
 
     setup_user_collections(client_id)
 
-    # Create keyword payload index for entry_type on the passages collection so
-    # filter_conditions={"entry_type": ...} queries don't raise HTTP 400.
+    # Create keyword payload indexes for every field that tools filter on so
+    # filter_conditions queries don't raise HTTP 400.
     try:
         from kbase.vector.sync_client import get_qdrant_client
-        from qdrant_client.models import PayloadSchemaType
-        passages_col = get_user_collection_names(client_id)["passages"]
+
         qc = get_qdrant_client()
-        qc.create_payload_index(
-            collection_name=passages_col,
-            field_name="entry_type",
-            field_schema=PayloadSchemaType.KEYWORD,
-        )
-        logger.info("Created entry_type payload index", collection=passages_col)
+        user_collections = get_user_collection_names(client_id)
+        for collection_key, fields in _PAYLOAD_KEYWORD_INDEXES.items():
+            collection = user_collections.get(collection_key)
+            if not collection:
+                continue
+            for field in fields:
+                _ensure_keyword_index(qc, collection, field)
     except Exception as e:
-        # Index may already exist (409) — that is fine.
-        if "already exists" not in str(e).lower() and "409" not in str(e):
-            logger.warning("Could not create entry_type index", error=str(e))
+        logger.warning("Could not ensure keyword payload indexes", error=str(e))
 
     _initialized_clients.add(client_id)
 

--- a/src/tools/style_profiles.py
+++ b/src/tools/style_profiles.py
@@ -83,6 +83,8 @@ def save_style_profile(
     if not rules and not sample_excerpts:
         return {"success": False, "error": "provide at least one rule or sample_excerpt"}
 
+    ensure_user_collections_once(client_id)
+
     # Validate channel
     warnings = []
     if channel is not None and channel not in VALID_CHANNELS:
@@ -174,6 +176,8 @@ def load_style_profile(name: str, client_id: str = "default") -> dict:
     if not name or not name.strip():
         return {"success": False, "error": "name cannot be empty"}
 
+    ensure_user_collections_once(client_id)
+
     try:
         client = _get_qdrant_client()
         from qdrant_client.http.models import Filter, FieldCondition, MatchValue
@@ -239,6 +243,8 @@ def update_style_profile(
         return {"success": False, "error": "name cannot be empty"}
     if not (0.0 < score_weight <= 1.0):
         return {"success": False, "error": "score_weight must be between 0.0 (exclusive) and 1.0"}
+
+    ensure_user_collections_once(client_id)
 
     # Load existing profile
     load_result = load_style_profile(name, client_id=client_id)
@@ -552,6 +558,8 @@ def search_style_profiles(
     """
     if not text or not text.strip():
         return {"success": False, "error": "text cannot be empty"}
+
+    ensure_user_collections_once(client_id)
 
     try:
         filter_conditions = {"channel": channel} if channel else None

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -24,3 +24,57 @@ def test_get_collection_names_custom_client():
     assert names["style_profiles"] == "acme-corp_writing_style_profiles"
     # Core collections unchanged
     assert names["rubrics"] == "writing_rubrics"
+
+
+def test_ensure_user_collections_once_creates_all_filter_indexes():
+    """Regression for Sentry MCP-WRITING-5 and MCP-WRITING-1.
+
+    search_passages filters on doc_type/language/domain/rubric_section and
+    load_style_profile filters on name — Qdrant returns HTTP 400 when the
+    keyword index is missing. Every filtered field must have an index
+    created on first use.
+    """
+    from src.tools import collections as collections_mod
+
+    collections_mod._initialized_clients.discard("idxtest")
+
+    mock_client = MagicMock()
+
+    with patch.object(collections_mod, "setup_user_collections") as setup:
+        setup.return_value = {}
+        with patch("kbase.vector.sync_client.get_qdrant_client", return_value=mock_client):
+            collections_mod.ensure_user_collections_once("idxtest")
+
+    indexed = {
+        (call.kwargs["collection_name"], call.kwargs["field_name"])
+        for call in mock_client.create_payload_index.call_args_list
+    }
+
+    passages = "idxtest_writing_passages"
+    profiles = "idxtest_writing_style_profiles"
+
+    # MCP-WRITING-5
+    assert (passages, "doc_type") in indexed
+    assert (passages, "language") in indexed
+    assert (passages, "domain") in indexed
+    assert (passages, "rubric_section") in indexed
+    # Existing entry_type index must still be created
+    assert (passages, "entry_type") in indexed
+
+    # MCP-WRITING-1
+    assert (profiles, "name") in indexed
+    assert (profiles, "channel") in indexed
+
+
+def test_ensure_user_collections_once_tolerates_existing_indexes():
+    """Creating an index that already exists must not raise."""
+    from src.tools import collections as collections_mod
+
+    collections_mod._initialized_clients.discard("dup")
+
+    mock_client = MagicMock()
+    mock_client.create_payload_index.side_effect = Exception("Index already exists (409)")
+
+    with patch.object(collections_mod, "setup_user_collections", return_value={}):
+        with patch("kbase.vector.sync_client.get_qdrant_client", return_value=mock_client):
+            collections_mod.ensure_user_collections_once("dup")  # must not raise


### PR DESCRIPTION
## Summary

Fixes two related Sentry issues caused by missing Qdrant payload (keyword) indexes on fields we filter by at query time. When Qdrant receives a `FieldCondition` on an unindexed payload field, it rejects the request with HTTP 400 / `UnexpectedResponse`, surfacing as errors on `search_passages` and `load_style_profile` / `update_style_profile`.

Seer root cause (both issues): the collection-provisioning path only ever created an index for `entry_type`, but tool handlers filter on `doc_type`, `language`, `domain`, `rubric_section` (passages) and `name`, `channel` (style_profiles). In addition, several style-profile tools bypassed `ensure_user_collections_once`, so the `name` index would never be created on first access.

### Fix

1. `src/tools/collections.py` — centralise the required keyword indexes in a `_PAYLOAD_KEYWORD_INDEXES` table and iterate over it from `ensure_user_collections_once`. Tolerant of "already exists" / 409 responses so repeat calls are safe.
2. `src/tools/style_profiles.py` — call `ensure_user_collections_once(client_id)` from `save_style_profile`, `load_style_profile`, `update_style_profile`, and `search_style_profiles` so the `name` index is guaranteed before any scroll / filter.
3. `tests/test_collections.py` — regression: asserts every `(collection, field)` tuple is created and that an "already exists" error is swallowed.

### Sentry

- MCP-WRITING-5 — `search_passages` 400 on `doc_type` filter
- MCP-WRITING-1 — `load_style_profile` 400 on `name` filter

### Files

- `src/tools/collections.py`
- `src/tools/style_profiles.py`
- `tests/test_collections.py`

### Test plan

- [ ] CI green
- [ ] Manual: first-time `search_passages` call with `doc_type="essay"` on a fresh client returns results (no 400)
- [ ] Manual: `load_style_profile(name="default")` returns the profile on a fresh client (no 400)

Labels: `sentry-triage`