### PR TITLE
feat(schema): Phase 4 - emit outputSchema via Pydantic response models

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,20 @@
+"""Pydantic response models for MCP tool outputSchema emission."""
+from src.models.responses import (
+    PatternScoreResult,
+    RubricScoreResult,
+    SimilarityResult,
+    StructureCheckResult,
+    StyleProfileSearchResult,
+    VerifyClaimsResult,
+    VocabularyFlagResult,
+)
+
+__all__ = [
+    "PatternScoreResult",
+    "RubricScoreResult",
+    "SimilarityResult",
+    "StructureCheckResult",
+    "StyleProfileSearchResult",
+    "VerifyClaimsResult",
+    "VocabularyFlagResult",
+]

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -1,0 +1,114 @@
+"""Permissive Pydantic v2 response models.
+
+Each model expresses the success/error duality of the corresponding
+MCP tool in a single schema. Only `success` is required; every other
+field is Optional so both branches validate against the same model.
+
+FastMCP reads these annotations to emit `outputSchema` and normalise
+structured-content payloads for MCP clients. Direct Python callers
+(including the test suite) still receive the raw dict unchanged —
+the `@mcp.tool()` decorator does not wrap the function.
+"""
+from typing import Any, List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    success: bool
+    error: Optional[str] = None
+
+
+class SimilarityResult(_Base):
+    """Shared by check_internal_similarity and check_external_similarity."""
+    overall_similarity_pct: Optional[float] = None
+    verdict: Optional[str] = None
+    verdict_threshold_pct: Optional[float] = None
+    sentences_checked: Optional[int] = None
+    flagged_sentences: Optional[List[Any]] = None
+    # External-specific / no-key fallback
+    reason: Optional[str] = None
+    message: Optional[str] = None
+    fallback_instructions: Optional[str] = None
+    key_sentences: Optional[List[Any]] = None
+
+
+class VerifyClaimsResult(_Base):
+    overall_evidence_score: Optional[float] = None
+    verdict: Optional[str] = None
+    total_claims: Optional[int] = None
+    verified_count: Optional[int] = None
+    claims: Optional[List[Any]] = None
+    domain: Optional[str] = None
+    note: Optional[str] = None
+
+
+class RubricScoreResult(_Base):
+    framework: Optional[str] = None
+    section: Optional[str] = None
+    text_length: Optional[int] = None
+    criteria_matched: Optional[int] = None
+    overall_score: Optional[float] = None
+    verdict: Optional[str] = None
+    criteria: Optional[List[Any]] = None
+    doc_context: Optional[str] = None
+
+
+class StructureCheckResult(_Base):
+    framework: Optional[str] = None
+    doc_type: Optional[str] = None
+    template_document_id: Optional[str] = None
+    total_sections: Optional[int] = None
+    required_sections: Optional[int] = None
+    present_count: Optional[int] = None
+    partial_count: Optional[int] = None
+    missing_count: Optional[int] = None
+    verdict: Optional[str] = None
+    scoring_method: Optional[str] = None
+    sections: Optional[List[Any]] = None
+    missing_required: Optional[List[str]] = None
+
+
+class PatternScoreResult(_Base):
+    """Union shape across score_writing_patterns modes (ai | semantic-ai | poetry | song | fiction)."""
+    mode: Optional[str] = None
+    language: Optional[str] = None
+    doc_type: Optional[str] = None
+    overall_score: Optional[float] = None
+    verdict: Optional[str] = None
+    threshold: Optional[float] = None
+    categories: Optional[Any] = None
+    summary: Optional[Any] = None
+    word_count: Optional[int] = None
+    # ai
+    page_equivalent: Optional[float] = None
+    # poetry / song
+    line_count: Optional[int] = None
+    stanza_count: Optional[int] = None
+    # fiction
+    paragraph_count: Optional[int] = None
+    sentence_count: Optional[int] = None
+    dialogue_line_count: Optional[int] = None
+    # semantic-ai
+    likelihood: Optional[float] = None
+    ai_mean_similarity: Optional[float] = None
+    human_mean_similarity: Optional[float] = None
+    ai_sample_count: Optional[int] = None
+    human_sample_count: Optional[int] = None
+    method: Optional[str] = None
+    note: Optional[str] = None
+
+
+class VocabularyFlagResult(_Base):
+    flagged_count: Optional[int] = None
+    verdict: Optional[str] = None
+    flagged: Optional[List[Any]] = None
+    language: Optional[str] = None
+    domain: Optional[str] = None
+    word_count: Optional[int] = None
+
+
+class StyleProfileSearchResult(_Base):
+    results: Optional[List[Any]] = None
+    total: Optional[int] = None

--- a/src/server.py
+++ b/src/server.py
@@ -32,6 +32,16 @@ from contextvars import ContextVar
 from typing import Optional, List
 from mcp.server.fastmcp import FastMCP, Context
 
+from src.models import (
+    PatternScoreResult,
+    RubricScoreResult,
+    SimilarityResult,
+    StructureCheckResult,
+    StyleProfileSearchResult,
+    VerifyClaimsResult,
+    VocabularyFlagResult,
+)
+
 # ContextVar set by BearerAuthMiddleware from X-Client-ID header (gateway-injected)
 current_client_id: ContextVar[str | None] = ContextVar("current_client_id", default=None)
 
@@ -620,7 +630,7 @@ def check_internal_similarity(
     threshold: float = 0.85,
     top_k_per_sentence: int = 3,
     verdict_threshold_pct: float = 30.0,
-) -> dict:
+) -> SimilarityResult:
     """
     Check if a passage is too similar to content already in the writing library.
 
@@ -658,7 +668,7 @@ def check_external_similarity(
     max_sentences: int = 3,
     verdict_threshold_pct: float = 30.0,
     search_results: Optional[list] = None,
-) -> dict:
+) -> SimilarityResult:
     """
     Check a passage against web content for similarity.
 
@@ -884,7 +894,7 @@ def search_style_profiles(
     ctx: Context,
     top_k: int = 3,
     channel: Optional[str] = None,
-) -> dict:
+) -> StyleProfileSearchResult:
     """
     Find saved style profiles most similar to a writing sample.
 
@@ -998,7 +1008,7 @@ def export_library(collection: str, ctx: Context, output_format: str = "json") -
 def verify_claims(
     text: str,
     domain: str = "general",
-) -> dict:
+) -> VerifyClaimsResult:
     """
     Detect potential hallucinations by checking claim-bearing sentences for
     explicit citation markers. Flags ghost stats (numbers without any source).
@@ -1142,7 +1152,7 @@ def score_against_rubric(
     section: Optional[str] = None,
     top_k: int = 5,
     doc_context: Optional[str] = None,
-) -> dict:
+) -> RubricScoreResult:
     """
     Score a document section against stored evaluation criteria for a given framework.
 
@@ -1242,7 +1252,7 @@ def check_structure(
     text: str,
     framework: str,
     doc_type: str,
-) -> dict:
+) -> StructureCheckResult:
     """
     Check whether a document draft covers all required sections from the stored template.
 
@@ -1366,7 +1376,7 @@ def score_writing_patterns(
     doc_type: Optional[str] = None,
     threshold: float = 0.25,
     top_k: int = 10,
-) -> dict:
+) -> PatternScoreResult:
     """
     Score text against craft patterns. Single entry point for all five scoring modes.
 
@@ -1555,7 +1565,7 @@ def flag_vocabulary(
     text: str,
     language: str = "en",
     domain: str = "general",
-) -> dict:
+) -> VocabularyFlagResult:
     """
     Scan text for AI-pattern vocabulary headwords present in the thesaurus.
 


### PR DESCRIPTION
## Summary

- Adds 7 permissive Pydantic v2 response models in `src/models/responses.py`
- Annotates 8 `@mcp.tool()` functions in `src/server.py` so FastMCP emits `outputSchema` to MCP clients
- No wrapping at call-time: `@mcp.tool()` only reads annotations for schema emission; direct Python callers (tests) continue to receive raw dicts

## Tools annotated

| Tool | Model |
|------|-------|
| `check_internal_similarity`, `check_external_similarity` | `SimilarityResult` |
| `search_style_profiles` | `StyleProfileSearchResult` |
| `verify_claims` | `VerifyClaimsResult` |
| `score_against_rubric` | `RubricScoreResult` |
| `check_structure` | `StructureCheckResult` |
| `score_writing_patterns` (ai / semantic-ai / poetry / song / fiction) | `PatternScoreResult` (union superset) |
| `flag_vocabulary` | `VocabularyFlagResult` |

## Design

- Each model expresses the `{success: True, ...}` | `{success: False, error: ...}` duality in a **single permissive schema**: only `success: bool` is required; every other field is `Optional[...] = None`.
- Base uses `ConfigDict(extra="allow")` so unknown/future fields pass through without schema churn.
- `PatternScoreResult` is a union superset across 5 modes (rather than discriminated union) to stay one-model-per-tool.

## Test plan

- [x] Full test suite run pre- and post-change: **263 passed / 28 failed (identical baseline)**. The 28 failures are pre-existing environmental issues (local `kbase` library not importable) — **not introduced by this PR**, verified via `git stash`.
- [x] `tests/test_phase1_surface.py` (17 tests) — all pass; `is sentinel` identity assertions confirmed unaffected by annotation changes.
- [x] `tests/test_ai_patterns.py` (40 tests) — all pass.
- [ ] Manual smoke: verify `outputSchema` appears in `tools/list` MCP response (follow-up).