### PR TITLE
Phase 5A: reduce MCP tool surface 40 → 20

### DIFF
--- a/.pair-programming-session.md
+++ b/.pair-programming-session.md
@@ -1,11 +1,11 @@
 # AI Pair Programming Session Report
 
-**Session End:** 2026-04-05 17:30:22
+**Session End:** 2026-04-21 16:08:31
 
 ## Session Statistics
 
-- **Files Modified:** 1
-- **Last Code Review:** 4/5/2026, 12:37:48 PM
+- **Files Modified:** 0
+- **Last Code Review:** 4/21/2026, 2:39:12 PM
 
 ## Available Tools
 

--- a/.project-structure.md
+++ b/.project-structure.md
@@ -1,13 +1,13 @@
 # Project Structure
 
-**Generated**: 2026-04-06 10:26:50
+**Generated**: 2026-04-21 16:19:22
 
 ## Directory Structure
 
-mcp-writing-library/
+great-poincare-497a40/
 ├── [.dockerignore](.dockerignore)
-├── [.env](.env)
 ├── [.env.example](.env.example)
+├── [.git](.git)
 ├── [.gitignore](.gitignore)
 ├── [.pair-programming-session.md](.pair-programming-session.md)
 ├── [.project-structure.md](.project-structure.md)
@@ -18,6 +18,7 @@ mcp-writing-library/
 ├── [Dockerfile](Dockerfile)
 ├── [README.md](README.md)
 ├── docs/
+│   ├── [phase-5a-tool-surface-proposal.md](docs/phase-5a-tool-surface-proposal.md)
 │   └── superpowers/
 │       └── plans/
 │           ├── [2026-03-15-mcp-writing-library.md](docs/superpowers/plans/2026-03-15-mcp-writing-library.md)
@@ -27,14 +28,8 @@ mcp-writing-library/
 ├── [pyproject.toml](pyproject.toml)
 ├── scripts/
 │   ├── [__init__.py](scripts/__init__.py)
-│   ├── __pycache__/
-│   │   ├── [__init__.cpython-312.pyc](scripts/__pycache__/__init__.cpython-312.pyc)
-│   │   └── [seed_from_markdown.cpython-312.pyc](scripts/__pycache__/seed_from_markdown.cpython-312.pyc)
 │   ├── data/
 │   │   ├── [__init__.py](scripts/data/__init__.py)
-│   │   ├── __pycache__/
-│   │   │   ├── [__init__.cpython-312.pyc](scripts/data/__pycache__/__init__.cpython-312.pyc)
-│   │   │   └── [thesaurus_wordlist.cpython-312.pyc](scripts/data/__pycache__/thesaurus_wordlist.cpython-312.pyc)
 │   │   └── [thesaurus_wordlist.py](scripts/data/thesaurus_wordlist.py)
 │   ├── [fix_style_profiles_indexes.py](scripts/fix_style_profiles_indexes.py)
 │   ├── [seed_creative_templates.py](scripts/seed_creative_templates.py)
@@ -51,8 +46,16 @@ mcp-writing-library/
 │   ├── [__init__.py](src/__init__.py)
 │   ├── __pycache__/
 │   │   ├── [__init__.cpython-312.pyc](src/__pycache__/__init__.cpython-312.pyc)
+│   │   ├── [__init__.cpython-314.pyc](src/__pycache__/__init__.cpython-314.pyc)
 │   │   ├── [sentry.cpython-312.pyc](src/__pycache__/sentry.cpython-312.pyc)
-│   │   └── [server.cpython-312.pyc](src/__pycache__/server.cpython-312.pyc)
+│   │   ├── [server.cpython-312.pyc](src/__pycache__/server.cpython-312.pyc)
+│   │   └── [server.cpython-314.pyc](src/__pycache__/server.cpython-314.pyc)
+│   ├── models/
+│   │   ├── [__init__.py](src/models/__init__.py)
+│   │   ├── __pycache__/
+│   │   │   ├── [__init__.cpython-312.pyc](src/models/__pycache__/__init__.cpython-312.pyc)
+│   │   │   └── [responses.cpython-312.pyc](src/models/__pycache__/responses.cpython-312.pyc)
+│   │   └── [responses.py](src/models/responses.py)
 │   ├── [sentry.py](src/sentry.py)
 │   ├── [server.py](src/server.py)
 │   └── tools/
@@ -69,6 +72,7 @@ mcp-writing-library/
 │       │   ├── [passages.cpython-312.pyc](src/tools/__pycache__/passages.cpython-312.pyc)
 │       │   ├── [plagiarism.cpython-312.pyc](src/tools/__pycache__/plagiarism.cpython-312.pyc)
 │       │   ├── [poetry_patterns.cpython-312.pyc](src/tools/__pycache__/poetry_patterns.cpython-312.pyc)
+│       │   ├── [qdrant_errors.cpython-312.pyc](src/tools/__pycache__/qdrant_errors.cpython-312.pyc)
 │       │   ├── [registry.cpython-312.pyc](src/tools/__pycache__/registry.cpython-312.pyc)
 │       │   ├── [rubrics.cpython-312.pyc](src/tools/__pycache__/rubrics.cpython-312.pyc)
 │       │   ├── [song_patterns.cpython-312.pyc](src/tools/__pycache__/song_patterns.cpython-312.pyc)
@@ -87,6 +91,7 @@ mcp-writing-library/
 │       ├── [passages.py](src/tools/passages.py)
 │       ├── [plagiarism.py](src/tools/plagiarism.py)
 │       ├── [poetry_patterns.py](src/tools/poetry_patterns.py)
+│       ├── [qdrant_errors.py](src/tools/qdrant_errors.py)
 │       ├── [registry.py](src/tools/registry.py)
 │       ├── [rubrics.py](src/tools/rubrics.py)
 │       ├── [song_patterns.py](src/tools/song_patterns.py)
@@ -99,21 +104,26 @@ mcp-writing-library/
 │   ├── [__init__.py](tests/__init__.py)
 │   ├── __pycache__/
 │   │   ├── [__init__.cpython-312.pyc](tests/__pycache__/__init__.cpython-312.pyc)
-│   │   ├── [conftest.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/conftest.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_ai_patterns.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_ai_patterns.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_collections.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_collections.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_consistency.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_consistency.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_evidence.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_evidence.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_export.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_export.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_passages.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_passages.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_plagiarism.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_plagiarism.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_rubrics.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_rubrics.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_style_profiles.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_style_profiles.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_styles.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_styles.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_templates.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_templates.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_terms.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_terms.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_thesaurus.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_thesaurus.cpython-312-pytest-9.0.2.pyc)
-│   │   └── [test_transport.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_transport.cpython-312-pytest-9.0.2.pyc)
+│   │   ├── [__init__.cpython-314.pyc](tests/__pycache__/__init__.cpython-314.pyc)
+│   │   ├── [conftest.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/conftest.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [conftest.cpython-314-pytest-9.0.2.pyc](tests/__pycache__/conftest.cpython-314-pytest-9.0.2.pyc)
+│   │   ├── [test_ai_patterns.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_ai_patterns.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_collections.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_collections.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_consistency.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_consistency.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_evidence.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_evidence.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_export.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_export.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_passages.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_passages.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_phase1_surface.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_phase1_surface.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_phase1_surface.cpython-314-pytest-9.0.2.pyc](tests/__pycache__/test_phase1_surface.cpython-314-pytest-9.0.2.pyc)
+│   │   ├── [test_plagiarism.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_plagiarism.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_qdrant_errors.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_qdrant_errors.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_rubrics.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_rubrics.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_style_profiles.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_style_profiles.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_styles.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_styles.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_templates.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_templates.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_terms.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_terms.cpython-312-pytest-9.0.3.pyc)
+│   │   ├── [test_thesaurus.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_thesaurus.cpython-312-pytest-9.0.3.pyc)
+│   │   └── [test_transport.cpython-312-pytest-9.0.3.pyc](tests/__pycache__/test_transport.cpython-312-pytest-9.0.3.pyc)
 │   ├── [conftest.py](tests/conftest.py)
 │   ├── [test_ai_patterns.py](tests/test_ai_patterns.py)
 │   ├── [test_collections.py](tests/test_collections.py)
@@ -121,7 +131,9 @@ mcp-writing-library/
 │   ├── [test_evidence.py](tests/test_evidence.py)
 │   ├── [test_export.py](tests/test_export.py)
 │   ├── [test_passages.py](tests/test_passages.py)
+│   ├── [test_phase1_surface.py](tests/test_phase1_surface.py)
 │   ├── [test_plagiarism.py](tests/test_plagiarism.py)
+│   ├── [test_qdrant_errors.py](tests/test_qdrant_errors.py)
 │   ├── [test_rubrics.py](tests/test_rubrics.py)
 │   ├── [test_style_profiles.py](tests/test_style_profiles.py)
 │   ├── [test_styles.py](tests/test_styles.py)

--- a/.todos-report.md
+++ b/.todos-report.md
@@ -1,25 +1,13 @@
 # TODO/FIXME Report
-Generated: 2026-04-05 06:18:05
-Total Items: 2
+Generated: 2026-04-21 18:19:22
+Total Items: 0
 
 ## 📝 Session Changes
 
-**Files Modified**: 3
-- Added: 2 ✅
-- Removed: 2 ❌
+**Files Modified**: 2
+- Added: 0 ✅
+- Removed: 1 ❌
 
 ---
 
-## NOTE (2)
-
-- **[src/tools/passages.py:401](src/tools/passages.py#L401)**
-  `This operation is non-atomic. If re-indexing fails after deletion,`
-
-- **[src/tools/terms.py:300](src/tools/terms.py#L300)**
-  `This operation is non-atomic. If re-indexing fails after deletion,`
-
-
-## Summary by File
-
-- [src/tools/passages.py](src/tools/passages.py): 1 item(s)
-- [src/tools/terms.py](src/tools/terms.py): 1 item(s)
+No TODO or FIXME comments found in the project.

--- a/docs/phase-5a-tool-surface-proposal.md
+++ b/docs/phase-5a-tool-surface-proposal.md
@@ -1,0 +1,54 @@
+# Phase 5A — Tool Surface Reduction (Final)
+
+**Date:** 2026-04-21
+**Status:** Approved — in implementation
+**Goal:** Reduce `src/server.py` MCP tool count from **40** to **20** via `manage_*` consolidation, `admin_add` merge, demotion of list registries to MCP resources, and removal of `setup_collections` from public surface.
+**Decisions:** aggressive collapse; breaking changes OK; demote `list_*` registries.
+
+## Final surface (20 tools)
+
+### Scoring / search — kept as-is (12)
+1. `search_passages`
+2. `search_terms`
+3. `check_internal_similarity`
+4. `check_external_similarity`
+5. `score_writing_patterns`
+6. `verify_claims`
+7. `score_evidence_density`
+8. `score_against_rubric`
+9. `check_structure`
+10. `score_voice_consistency`
+11. `detect_authorship_shift`
+12. `flag_vocabulary`
+
+### Merged CRUD / manage (6)
+13. **`manage_passage(action, ...)`** — `add` (single or `items=list`), `update`, `delete`, `correction` (original/corrected pair). Replaces `add_passage` + `batch_add_passages` + `update_passage` + `delete_passage` + `record_correction`.
+14. **`manage_term(action, ...)`** — `add` (single or `items=list`), `update`, `delete`. Replaces `add_term` + `batch_add_terms` + `update_term` + `delete_term`.
+15. **`manage_style_profile(action, ...)`** — `save` (upsert), `load` (by name), `search` (by text/channel), `list`, `harvest-corrections`. Replaces `save_style_profile` + `update_style_profile` + `load_style_profile` + `search_style_profiles` + `list_style_profiles` + `harvest_corrections_to_profile`.
+16. **`search_thesaurus(query, rich=False, ...)`** — unified; `rich=True` returns alternatives + collocations + why-avoid (former `suggest_alternatives`). Replaces `search_thesaurus` + `suggest_alternatives`.
+17. **`manage_contributions(action, ...)`** — `list`, `review`. Replaces `list_contributions` + `review_contribution`.
+18. **`manage_library(action, ...)`** — `stats`, `export`. Replaces `get_library_stats` + `export_library`. (`setup` is internal only.)
+
+### Admin writes merged (1)
+19. **`admin_add(kind, ...)`** — `kind ∈ {rubric, template, thesaurus}` with per-kind parameter schemas. Replaces `add_rubric_criterion` + `add_template` + `add_thesaurus_entry`. Admin-only; non-admin → contribution queue (unchanged semantics).
+
+### Admin utility kept (1)
+20. `harvest_corrections_to_profile` → folded into `manage_style_profile(action="harvest-corrections")` (already counted at #15). Slot 20 is reserved for reconsideration — likely retained at 20 total once verified against tests.
+
+*(Actual count after folding: 19. Placeholder for any slot that resists merging during implementation.)*
+
+### Demoted to MCP resources (3 removed from tool surface)
+- `list_styles` → `writing-library://styles`
+- `list_rubric_frameworks` → `writing-library://rubric-frameworks`
+- `list_templates` → `writing-library://templates`
+
+### Removed (1)
+- `setup_collections` — kept as internal helper, called lazily on first write.
+
+## Implementation phases
+
+1. **Server refactor** — rewrite `src/server.py` tool registrations to the 19–20 new tools. Keep existing `src/tools/*` modules unchanged (merges happen only at the registration layer).
+2. **Resources** — add FastMCP `@mcp.resource()` for the three list registries.
+3. **Tests** — update `tests/test_phase1_surface.py` for new tool names and action-dispatch shapes. Add dispatch tests per `manage_*` action.
+4. **Run suite** — expect 263-ish passing; fix any breakage introduced by the refactor (not the pre-existing `kbase` import failures).
+5. **PR** — separate PR from Phase 4.

--- a/src/server.py
+++ b/src/server.py
@@ -1,29 +1,28 @@
 """
-MCP Writing Library Server — FastMCP tool definitions.
+MCP Writing Library Server — FastMCP tool definitions (Phase 5A: 20-tool surface).
 
-Tools (see Patterns 1–9 in CLAUDE.md for chained workflows):
+Scoring / search (12, unchanged):
+    search_passages, search_terms, check_internal_similarity, check_external_similarity,
+    score_writing_patterns, verify_claims, score_evidence_density, score_against_rubric,
+    check_structure, score_voice_consistency, detect_authorship_shift, flag_vocabulary
 
-    Passages (per-user):
-        search_passages, add_passage, update_passage, delete_passage, batch_add_passages
-    Terminology (per-user; add_term routes share→library|queue|personal):
-        search_terms, add_term, update_term, delete_term, batch_add_terms, record_correction
-    Style profiles (per-user, channel-tagged):
-        save_style_profile, load_style_profile, update_style_profile,
-        search_style_profiles, list_style_profiles, harvest_corrections_to_profile
-    Thesaurus (shared, admin-write; non-admin calls route to contribution queue):
-        add_thesaurus_entry, search_thesaurus, suggest_alternatives, flag_vocabulary
-    Rubrics & templates (shared, admin-write; non-admin calls route to queue):
-        add_rubric_criterion, score_against_rubric, list_rubric_frameworks,
-        add_template, check_structure, list_templates
-    Similarity & craft:
-        check_internal_similarity (library), check_external_similarity (web via Tavily),
-        score_writing_patterns (mode ∈ {ai, semantic-ai, poetry, song, fiction})
-    Evidence & voice:
-        verify_claims, score_evidence_density,
-        score_voice_consistency, detect_authorship_shift
-    Infrastructure:
-        list_styles, get_library_stats, setup_collections (admin),
-        export_library, list_contributions, review_contribution (admin)
+Merged CRUD / manage (6):
+    manage_passage(action ∈ {add, update, delete, correction})
+    manage_term(action ∈ {add, update, delete})  — share-branching preserved
+    manage_style_profile(action ∈ {save, load, search, list, harvest-corrections})
+    search_thesaurus(query, rich=False, ...)  — rich=True = former suggest_alternatives
+    manage_contributions(action ∈ {list, review})
+    manage_library(action ∈ {stats, export})
+
+Admin writes merged (1):
+    admin_add(kind ∈ {rubric, template, thesaurus})
+
+Resources (3, demoted from list_* tools):
+    writing-library://styles
+    writing-library://rubric-frameworks
+    writing-library://templates
+
+Setup is internal: setup_collections is called lazily on first write; no longer a public tool.
 """
 import os
 import sys
@@ -159,20 +158,24 @@ def _build_mcp() -> FastMCP:
     transport = os.getenv("TRANSPORT", "stdio")
     instructions = (
         "Writing-quality, evidence, and document-intelligence tools backed by Qdrant.\n\n"
-        "Key workflows (see CLAUDE.md Patterns 1–9 for full examples):\n"
+        "20-tool surface (action-dispatch for CRUD, kind-dispatch for admin writes):\n"
         "  1. Vocabulary review: search_terms → apply preferred term with `why` as rationale.\n"
-        "  2. Seed model passages: check_internal_similarity (verdict='clean') → add_passage.\n"
-        "  3. Similarity before adding: always check_internal_similarity first.\n"
-        "  4. Style profile extraction: list_styles → save_style_profile (channel-tagged).\n"
-        "  5. Craft scoring (unified): score_writing_patterns with mode∈{ai|semantic-ai|poetry|song|fiction}.\n"
-        "  6. Evidence verification: verify_claims (ghost_stat=True always blocks) + score_evidence_density.\n"
-        "  7. Rubric alignment: score_against_rubric (usaid|undp|global-fund|eu|general).\n"
-        "  8. Structure check: check_structure (retrieves stored template, flags missing sections).\n"
-        "  9. Vocabulary flagging: flag_vocabulary for lexical AI tells; suggest_alternatives for rich swaps.\n\n"
-        "Tenancy: per-user collections ({client_id}_writing_*) are isolated; thesaurus/rubrics/templates/terms_shared "
-        "are shared. add_term/add_thesaurus_entry/add_rubric_criterion/add_template route share→library|queue|personal "
-        "based on ADMIN_CLIENT_ID. Use check_internal_similarity for your own library, check_external_similarity "
-        "to scan the public web via Tavily."
+        "  2. Seed model passages: check_internal_similarity → manage_passage(action='add').\n"
+        "  3. Corrections pair: manage_passage(action='correction', original=..., corrected=...).\n"
+        "  4. Style profiles: manage_style_profile(action ∈ {save, load, search, list, harvest-corrections}).\n"
+        "  5. Craft scoring: score_writing_patterns(mode ∈ {ai|semantic-ai|poetry|song|fiction}).\n"
+        "  6. Evidence: verify_claims (ghost_stat=True always blocks) + score_evidence_density.\n"
+        "  7. Rubric alignment: score_against_rubric; admins add criteria via admin_add(kind='rubric').\n"
+        "  8. Structure check: check_structure; admins add templates via admin_add(kind='template').\n"
+        "  9. Vocabulary: flag_vocabulary for lexical tells; search_thesaurus(rich=True) for swaps.\n"
+        " 10. Contributions: manage_contributions(action ∈ {list, review}). Admins only for review.\n"
+        " 11. Library ops: manage_library(action ∈ {stats, export}).\n\n"
+        "Registries live as MCP resources: writing-library://styles, "
+        "writing-library://rubric-frameworks, writing-library://templates.\n\n"
+        "Tenancy: per-user collections ({client_id}_writing_*) are isolated; thesaurus/rubrics/"
+        "templates/terms_shared are shared. manage_term(share=True)/admin_add route to library "
+        "(admins) or the contribution queue (non-admins) based on ADMIN_CLIENT_ID. Use "
+        "check_internal_similarity for your own library, check_external_similarity for the web via Tavily."
     )
     if transport == "http":
         host = os.getenv("HOST", "0.0.0.0")
@@ -182,6 +185,10 @@ def _build_mcp() -> FastMCP:
 
 mcp = _build_mcp()
 
+
+# ===========================================================================
+# 1. SCORING / SEARCH (12 tools, unchanged)
+# ===========================================================================
 
 @mcp.tool()
 def search_passages(
@@ -197,27 +204,17 @@ def search_passages(
     """
     Search for exemplary writing passages by semantic similarity.
 
-    Use this to find model paragraphs when drafting or reviewing documents.
-    Returns passages ranked by relevance with quality notes explaining what makes each one effective.
-
     Args:
         query: What you need (e.g. "executive summary opening about health equity")
-        doc_type: Filter by type: executive-summary|concept-note|policy-brief|report|annual-report|monitoring-report|financial-report|assessment|email|tor|general
+        doc_type: Filter by type: executive-summary|concept-note|policy-brief|report|email|tor|general
         language: Filter by language: en|pt
         domain: Filter by domain: srhr|governance|climate|general|m-and-e
-        style: Filter by style: narrative|data-driven|argumentative|minimalist|
-               formal|conversational|donor-facing|advocacy|
-               undp|global-fund|danilo-voice|
-               ai-sounding|bureaucratic|jargon-heavy
-               Call list_styles() to see descriptions.
-        rubric_section: Filter by rubric section (e.g. "results-framework",
-                        "technical-approach", "sustainability", "community-led").
-                        Retrieves model passages for the specific section you are trying to strengthen.
+        style: Filter by style label (see writing-library://styles resource)
+        rubric_section: Filter by rubric section (e.g. "results-framework")
         top_k: Number of results (default 5, max 20)
 
     Returns:
-        List of matching passages with scores, quality notes, tags, style labels,
-        and rubric_section where present
+        List of matching passages with scores, quality notes, tags, style labels, rubric_section
     """
     from src.tools.passages import search_passages as _search
     return _search(
@@ -225,74 +222,6 @@ def search_passages(
         style=style, rubric_section=rubric_section, top_k=top_k,
         client_id=_client_id(ctx),
     )
-
-
-@mcp.tool()
-def add_passage(
-    text: str,
-    ctx: Context,
-    doc_type: str = "general",
-    language: str = "en",
-    domain: str = "general",
-    quality_notes: str = "",
-    tags: Optional[List[str]] = None,
-    source: str = "manual",
-    style: Optional[List[str]] = None,
-    rubric_section: Optional[str] = None,
-) -> dict:
-    """
-    Store an exemplary writing passage in the library.
-
-    Use this when you produce a passage you are proud of, or to seed the library
-    with models from reference documents (UNDP HDR, Global Fund reports, M&E assessments, TORs, etc.).
-
-    Args:
-        text: The passage (one or more paragraphs)
-        doc_type: Context: executive-summary|concept-note|policy-brief|report|email|tor|general
-        language: Language: en|pt
-        domain: Thematic area: srhr|governance|climate|general|m-and-e
-        quality_notes: What makes this passage good (helps future retrieval)
-        tags: Labels for retrieval e.g. ["discursive", "findings", "contrast"]
-        source: Where the passage came from (e.g. "undp-hdr-2024", "manual")
-        style: Style labels e.g. ["narrative", "donor-facing"].
-               Call list_styles() to see all valid values.
-               Unknown values are warned but do not block the save.
-        rubric_section: Optional rubric section this passage models
-                        (e.g. "results-framework", "technical-approach", "sustainability").
-                        Enables retrieval via search_passages(rubric_section=...) to find
-                        model passages for a specific section you are trying to strengthen.
-
-    Returns:
-        document_id, chunks_created, and warnings on success
-    """
-    from src.tools.passages import add_passage as _add
-    return _add(
-        text=text, doc_type=doc_type, language=language, domain=domain,
-        quality_notes=quality_notes, tags=tags or [], source=source,
-        style=style or [], rubric_section=rubric_section,
-        client_id=_client_id(ctx),
-    )
-
-
-@mcp.tool()
-def list_styles() -> dict:
-    """
-    Return all writing style labels with descriptions, grouped by category.
-
-    Use before calling add_passage or search_passages with a style argument
-    to see what values are valid.
-
-    Categories:
-        structural   — narrative, data-driven, argumentative, minimalist
-        tonal        — formal, conversational, donor-facing, advocacy
-        source       — undp, global-fund, danilo-voice
-        anti-pattern — ai-sounding, bureaucratic, jargon-heavy
-
-    Returns:
-        styles grouped by category with descriptions, total count
-    """
-    from src.tools.styles import list_styles as _list
-    return _list()
 
 
 @mcp.tool()
@@ -306,11 +235,8 @@ def search_terms(
     """
     Search the terminology dictionary for preferred consultant vocabulary.
 
-    Use this when choosing between terms, or when reviewing text for inappropriate language.
-    Returns preferred terms, what to avoid, and why — with good/bad usage examples.
-
     Args:
-        query: What you're looking for (e.g. "person living with HIV", "leverage", "unprecedented")
+        query: What you're looking for (e.g. "person living with HIV", "leverage")
         domain: Filter by domain: srhr|governance|climate|general|m-and-e
         language: Filter by language: en|pt
         top_k: Number of results (default 8)
@@ -320,307 +246,6 @@ def search_terms(
     """
     from src.tools.terms import search_terms as _search
     return _search(query=query, domain=domain, language=language, top_k=top_k, client_id=_client_id(ctx))
-
-
-@mcp.tool()
-def add_term(
-    preferred: str,
-    ctx: Context,
-    avoid: str = "",
-    domain: str = "general",
-    language: str = "en",
-    why: str = "",
-    example_bad: str = "",
-    example_good: str = "",
-    share: bool = False,
-    note: str = "",
-) -> dict:
-    """
-    Add a terminology entry.
-
-    By default (share=False), the entry is written to the caller's personal
-    dictionary. Pass share=True to contribute to the shared library: admins
-    write directly, non-admins submit to the moderation queue.
-
-    Args:
-        preferred: The term to use (e.g. "rights-holder", "key populations")
-        avoid: Term to avoid (e.g. "victim", "vulnerable groups")
-        domain: Thematic area: srhr|governance|climate|general|m-and-e
-        language: Language: en|pt|both
-        why: Reason for preference
-        example_bad: Example of poor usage
-        example_good: Example of correct usage
-        share: If True, target the shared library (direct for admins, queue for others).
-               If False (default), target the caller's personal dictionary.
-        note: Optional note for moderators (only used for queued contributions).
-
-    Returns:
-        Includes routed_to: "personal" | "library" | "queue".
-    """
-    caller = _client_id(ctx)
-
-    if not share:
-        from src.tools.terms import add_term as _add
-        result = _add(
-            preferred=preferred, avoid=avoid, domain=domain, language=language,
-            why=why, example_bad=example_bad, example_good=example_good,
-            client_id=caller,
-        )
-        if result.get("success"):
-            result["routed_to"] = "personal"
-        return result
-
-    # share=True
-    if _require_admin(ctx) is None:
-        from uuid import uuid4
-        from src.tools.collections import get_core_collection_names
-        from src.tools.registry import VALID_DOMAINS
-        if domain not in VALID_DOMAINS:
-            return {"success": False, "error": f"Invalid domain '{domain}'. Must be one of: {sorted(VALID_DOMAINS)}"}
-        if not preferred or not preferred.strip():
-            return {"success": False, "error": "preferred term cannot be empty"}
-        try:
-            from kbase.vector.sync_indexing import index_document
-        except ImportError:
-            return {"success": False, "error": "kbase indexing unavailable"}
-        collection = get_core_collection_names().get("terms_shared", "writing_terms_shared")
-        document_id = str(uuid4())
-        content_parts = [
-            f"Preferred term: {preferred}",
-            f"Avoid: {avoid}" if avoid else "",
-            f"Why: {why}" if why else "",
-            f"Bad example: {example_bad}" if example_bad else "",
-            f"Good example: {example_good}" if example_good else "",
-            f"Domain: {domain}",
-            f"Language: {language}",
-        ]
-        content = "\n".join(p for p in content_parts if p)
-        metadata = {
-            "client_id": "shared", "preferred": preferred, "avoid": avoid,
-            "domain": domain, "language": language, "why": why,
-            "example_bad": example_bad, "example_good": example_good,
-            "entry_type": "term", "contributed_by": caller,
-        }
-        try:
-            point_ids = index_document(
-                collection_name=collection, document_id=document_id,
-                title=preferred, content=content, metadata=metadata,
-                context_mode="metadata",
-            )
-            return {
-                "success": True, "document_id": document_id,
-                "chunks_created": len(point_ids), "collection": collection,
-                "routed_to": "library",
-            }
-        except Exception as e:
-            return {"success": False, "error": str(e)}
-
-    # share=True + non-admin → queue
-    from src.tools.contributions import contribute_term as _contribute
-    result = _contribute(
-        preferred=preferred, contributed_by=caller, avoid=avoid, domain=domain,
-        language=language, why=why, example_bad=example_bad,
-        example_good=example_good, note=note,
-    )
-    if result.get("success"):
-        _notify_contribution(result.get("contribution_id", ""), "terms", preferred, caller)
-        result["routed_to"] = "queue"
-    return result
-
-
-@mcp.tool()
-def record_correction(
-    original: str,
-    corrected: str,
-    issue_type: str,
-    ctx: Context,
-    doc_type: str = "general",
-    language: str = "en",
-    domain: str = "general",
-    source: str = "manual",
-) -> dict:
-    """
-    Store a before/after correction pair so the library learns from real edits.
-
-    Call this whenever an AI-generated or poor passage is rewritten. The original
-    is stored tagged 'ai-corrected' (negative example); the corrected version is
-    stored tagged 'human-corrected' (positive example). Both share a correction_id
-    so they can be retrieved as a pair.
-
-    Over time these pairs feed score_semantic_ai_likelihood() — the more corrections
-    are stored, the stronger the semantic signal for what DS-MOZ prose looks like
-    when fixed versus when it reads as AI-generated.
-
-    Args:
-        original: The original (poor/AI-sounding) passage
-        corrected: The improved replacement
-        issue_type: What was wrong — e.g. "ai-patterns", "passive-voice",
-                    "hollow-intensifier", "deficit-framing", "missing-connector"
-        doc_type: Document context: concept-note|report|tor|general|etc.
-        language: Language: en|pt
-        domain: Thematic area: srhr|governance|climate|general|m-and-e
-        source: Origin of the correction (e.g. "danilo-correction", "editorial-review")
-
-    Returns:
-        {success, correction_id, collection, original: {document_id, chunks_created},
-         corrected: {document_id, chunks_created}}
-    """
-    from src.tools.passages import record_correction as _record
-    return _record(
-        original=original, corrected=corrected, issue_type=issue_type,
-        doc_type=doc_type, language=language, domain=domain, source=source,
-        client_id=_client_id(ctx),
-    )
-
-
-@mcp.tool()
-def delete_passage(document_id: str, ctx: Context) -> dict:
-    """
-    Delete a passage from the writing library by document_id.
-
-    Use this to remove an outdated, duplicated, or incorrect passage.
-    The document_id is returned by add_passage or search_passages.
-
-    Args:
-        document_id: UUID of the passage to delete (from add_passage or search_passages)
-
-    Returns:
-        {success: True, document_id, deleted: True} on success,
-        or {success: False, error} if not found or deletion fails
-    """
-    from src.tools.passages import delete_passage as _delete
-    return _delete(document_id=document_id, client_id=_client_id(ctx))
-
-
-@mcp.tool()
-def update_passage(
-    document_id: str,
-    ctx: Context,
-    text: Optional[str] = None,
-    doc_type: Optional[str] = None,
-    language: Optional[str] = None,
-    domain: Optional[str] = None,
-    quality_notes: Optional[str] = None,
-    tags: Optional[List[str]] = None,
-    source: Optional[str] = None,
-    style: Optional[List[str]] = None,
-) -> dict:
-    """
-    Update one or more fields of an existing passage.
-
-    Merges the provided fields with existing metadata and re-indexes.
-    At least one field must be supplied. Fields not provided remain unchanged.
-
-    Args:
-        document_id: UUID of the passage to update
-        text: Replacement passage text (re-embeds the document)
-        doc_type: New document type: executive-summary|concept-note|policy-brief|report|annual-report|monitoring-report|financial-report|assessment|email|tor|general
-        language: New language: en|pt
-        domain: New domain: srhr|governance|climate|general|m-and-e
-        quality_notes: Updated quality notes
-        tags: Replacement tag list (replaces, does not append)
-        source: Updated source reference
-        style: Replacement style label list. Call list_styles() to see valid values.
-
-    Returns:
-        {success: True, document_id, updated_fields: [...], chunks_created, warnings} on success,
-        or {success: False, error} on failure
-    """
-    from src.tools.passages import update_passage as _update
-    return _update(
-        document_id=document_id,
-        text=text, doc_type=doc_type, language=language, domain=domain,
-        quality_notes=quality_notes, tags=tags, source=source, style=style,
-        client_id=_client_id(ctx),
-    )
-
-
-@mcp.tool()
-def delete_term(document_id: str, ctx: Context) -> dict:
-    """
-    Delete a terminology entry from the writing library by document_id.
-
-    Use this to remove a term that is no longer applicable or was added in error.
-    The document_id is returned by add_term or search_terms.
-
-    Args:
-        document_id: UUID of the term to delete (from add_term or search_terms)
-
-    Returns:
-        {success: True, document_id, deleted: True} on success,
-        or {success: False, error} if not found or deletion fails
-    """
-    from src.tools.terms import delete_term as _delete
-    return _delete(document_id=document_id, client_id=_client_id(ctx))
-
-
-@mcp.tool()
-def update_term(
-    document_id: str,
-    ctx: Context,
-    preferred: Optional[str] = None,
-    avoid: Optional[str] = None,
-    domain: Optional[str] = None,
-    language: Optional[str] = None,
-    why: Optional[str] = None,
-    example_bad: Optional[str] = None,
-    example_good: Optional[str] = None,
-) -> dict:
-    """
-    Update one or more fields of an existing terminology entry.
-
-    Merges the provided fields with existing metadata and re-indexes.
-    At least one field must be supplied. Fields not provided remain unchanged.
-
-    Args:
-        document_id: UUID of the term to update
-        preferred: New preferred term
-        avoid: Updated term to avoid
-        domain: New domain: srhr|governance|climate|general|m-and-e
-        language: New language: en|pt|both
-        why: Updated rationale for preference
-        example_bad: Updated bad usage example
-        example_good: Updated good usage example
-
-    Returns:
-        {success: True, document_id, updated_fields: [...], chunks_created} on success,
-        or {success: False, error} on failure
-    """
-    from src.tools.terms import update_term as _update
-    return _update(
-        document_id=document_id,
-        preferred=preferred, avoid=avoid, domain=domain, language=language,
-        why=why, example_bad=example_bad, example_good=example_good,
-        client_id=_client_id(ctx),
-    )
-
-
-@mcp.tool()
-def get_library_stats(ctx: Context) -> dict:
-    """
-    Return point counts for both Qdrant collections.
-
-    Use this to verify the library is populated and working.
-
-    Returns:
-        Stats for writing_passages and writing_terms collections
-    """
-    from src.tools.collections import get_stats
-    return get_stats(client_id=_client_id(ctx))
-
-
-@mcp.tool()
-def setup_collections(ctx: Context) -> dict:
-    """
-    **Admin only.** Create or verify Qdrant collections for the writing library.
-
-    Run this once on first setup, or to verify collections exist after a Qdrant restart.
-
-    Returns:
-        Status for each collection (created|already_exists|error)
-    """
-    from src.tools.collections import setup_collections as _setup
-    return _setup(client_id=_client_id(ctx))
 
 
 @mcp.tool()
@@ -634,30 +259,19 @@ def check_internal_similarity(
     """
     Check if a passage is too similar to content already in the writing library.
 
-    Use this when deduplicating before adding a passage, or when auditing a draft
-    for accidental self-plagiarism against previously-stored content. Splits the
-    text into sentences and searches each against the writing_passages collection.
-
-    Use `check_internal_similarity` for your own library; use
-    `check_external_similarity` to scan the public web via Tavily.
-
     Args:
         text: The passage to check
         threshold: Cosine similarity threshold to flag a sentence (default 0.85)
-        top_k_per_sentence: Max matches to retrieve per sentence (default 3)
+        top_k_per_sentence: Max matches per sentence (default 3)
         verdict_threshold_pct: % of sentences flagged to trigger overall "flagged" verdict (default 30)
 
     Returns:
-        overall_similarity_pct, verdict (clean|flagged), and list of flagged sentences
-        with their matching library entries (document_id, score, excerpt, source)
+        overall_similarity_pct, verdict (clean|flagged), list of flagged sentences with matches
     """
     from src.tools.plagiarism import check_internal_similarity as _check
     return _check(
-        text=text,
-        threshold=threshold,
-        top_k_per_sentence=top_k_per_sentence,
-        verdict_threshold_pct=verdict_threshold_pct,
-        client_id=_client_id(ctx),
+        text=text, threshold=threshold, top_k_per_sentence=top_k_per_sentence,
+        verdict_threshold_pct=verdict_threshold_pct, client_id=_client_id(ctx),
     )
 
 
@@ -672,699 +286,30 @@ def check_external_similarity(
     """
     Check a passage against web content for similarity.
 
-    Use `check_external_similarity` for web/public-internet comparisons; use
-    `check_internal_similarity` to compare against your own library first.
-
-    Default mode (search_results=None): fetches web results via the Tavily API
-    (requires TAVILY_API_KEY) and scores them against the text. If the API key
-    is missing, returns fallback instructions for manual search.
-
-    Scoring mode (search_results provided): skips the web fetch and scores the
-    supplied Tavily-style results directly — use this after manually calling
-    mcp__MCP_DOCKER__tavily_search when no API key is configured.
+    Default mode (search_results=None): fetches via Tavily API (TAVILY_API_KEY).
+    Scoring mode (search_results provided): skips web fetch, scores provided results.
 
     Args:
         text: The passage to check
-        threshold: Cosine similarity threshold to flag a match (default 0.75)
+        threshold: Cosine similarity threshold (default 0.75)
         max_sentences: Number of key sentences to search (default 3)
-        verdict_threshold_pct: % of sentences flagged to trigger "flagged" verdict (default 30)
-        search_results: Optional pre-fetched list of {url, content, title} dicts.
-                        If provided, web search is skipped.
+        verdict_threshold_pct: % threshold for "flagged" verdict (default 30)
+        search_results: Optional pre-fetched list of {url, content, title} dicts
 
     Returns:
-        overall_similarity_pct, verdict (clean|flagged), flagged sentences with sources.
+        overall_similarity_pct, verdict (clean|flagged), flagged sentences with sources
     """
     if search_results is not None:
         from src.tools.plagiarism import score_external_similarity as _score
         return _score(
-            text=text,
-            search_results=search_results,
-            threshold=threshold,
-            verdict_threshold_pct=verdict_threshold_pct,
+            text=text, search_results=search_results,
+            threshold=threshold, verdict_threshold_pct=verdict_threshold_pct,
         )
     from src.tools.plagiarism import check_external_similarity as _check
     return _check(
-        text=text,
-        threshold=threshold,
-        max_sentences=max_sentences,
+        text=text, threshold=threshold, max_sentences=max_sentences,
         verdict_threshold_pct=verdict_threshold_pct,
     )
-
-
-@mcp.tool()
-def save_style_profile(
-    name: str,
-    style_scores: dict,
-    rules: list,
-    anti_patterns: list,
-    sample_excerpts: list,
-    ctx: Context,
-    description: str = "",
-    source_documents: list = [],
-    channel: Optional[str] = None,
-) -> dict:
-    """
-    Save a writing style profile extracted from writing samples.
-
-    After analysing 2–5 writing samples against the 14 style dimensions,
-    call this to persist the profile in Qdrant for future retrieval.
-
-    Workflow:
-        1. User shares 2–5 writing samples
-        2. Claude analyses them against list_styles() dimensions
-        3. Claude calls save_style_profile() with the resulting profile
-        4. Use load_style_profile() or search_style_profiles() to retrieve later
-
-    Args:
-        name: Unique profile name (e.g. "danilo-voice-pt", "lambda-proposals")
-        style_scores: Dict mapping style labels to scores 0.0–1.0
-                      (e.g. {"narrative": 0.8, "conversational": 0.7})
-        rules: Writing rules inferred from the samples
-               (e.g. ["Uses em-dashes for asides", "Avoids passive voice"])
-        anti_patterns: Patterns absent or contrary to this style
-                       (e.g. ["'leverage'", "Excessive nominalisations"])
-        sample_excerpts: Short representative quotes from the writing samples
-        description: Human-readable summary of the style
-        source_documents: Names or titles of the writing samples analysed
-        channel: Publishing surface this profile targets
-                 (linkedin|facebook|instagram|twitter|whatsapp|tiktok|
-                  blog|newsletter|substack|email|report|proposal|
-                  executive-summary|tor|press-release|presentation|general)
-
-    Returns:
-        {success, name, document_id, chunks_created, warnings}
-    """
-    from src.tools.style_profiles import save_style_profile as _save
-    return _save(
-        name=name,
-        style_scores=style_scores,
-        rules=rules,
-        anti_patterns=anti_patterns,
-        sample_excerpts=sample_excerpts,
-        description=description,
-        source_documents=source_documents,
-        channel=channel,
-        client_id=_client_id(ctx),
-    )
-
-
-@mcp.tool()
-def load_style_profile(name: str, ctx: Context) -> dict:
-    """
-    Load a saved writing style profile by exact name.
-
-    Use this to retrieve a profile previously saved with save_style_profile(),
-    for example to guide writing generation or passage retrieval.
-
-    Args:
-        name: Profile name as used in save_style_profile (e.g. "danilo-voice-pt")
-
-    Returns:
-        {success, profile} with full profile payload, or {success: False, error}
-    """
-    from src.tools.style_profiles import load_style_profile as _load
-    return _load(name=name, client_id=_client_id(ctx))
-
-
-@mcp.tool()
-def update_style_profile(
-    name: str,
-    ctx: Context,
-    new_style_scores: Optional[dict] = None,
-    new_rules: Optional[List[str]] = None,
-    new_anti_patterns: Optional[List[str]] = None,
-    new_sample_excerpts: Optional[List[str]] = None,
-    new_source_documents: Optional[List[str]] = None,
-    description: Optional[str] = None,
-    channel: Optional[str] = None,
-    score_weight: float = 0.3,
-) -> dict:
-    """
-    Merge new writing evidence into an existing style profile without overwriting it.
-
-    Call this after analysing new writing samples from the same author — it blends
-    the new scores with the existing profile rather than resetting it. Over time
-    this builds a richer, more accurate fingerprint of the author's voice.
-
-    Style scores are blended: updated = (1 - score_weight) * existing + score_weight * new.
-    Rules and anti_patterns are unioned (no duplicates). Sample excerpts are appended
-    and capped at 20.
-
-    Args:
-        name: Profile name to update (must already exist via save_style_profile)
-        new_style_scores: New dimension scores to blend in (0.0–1.0 per dimension)
-        new_rules: Additional writing rules to add (duplicates ignored)
-        new_anti_patterns: Additional anti-patterns to add (duplicates ignored)
-        new_sample_excerpts: New representative quotes to append
-        new_source_documents: Additional source document names to record
-        description: Replace the description if provided
-        channel: Update the publishing channel tag
-                 (linkedin|facebook|instagram|email|report|proposal|general|...)
-        score_weight: How much weight to give new scores (default 0.3 = 30% new, 70% existing).
-                      Use 0.5 when the new samples are equally representative.
-
-    Returns:
-        {success, name, document_id, updated_fields, chunks_created, score_weight_used, warnings}
-    """
-    from src.tools.style_profiles import update_style_profile as _update
-    return _update(
-        name=name,
-        new_style_scores=new_style_scores,
-        new_rules=new_rules,
-        new_anti_patterns=new_anti_patterns,
-        new_sample_excerpts=new_sample_excerpts,
-        new_source_documents=new_source_documents,
-        description=description,
-        channel=channel,
-        score_weight=score_weight,
-        client_id=_client_id(ctx),
-    )
-
-
-@mcp.tool()
-def harvest_corrections_to_profile(
-    profile_name: str,
-    ctx: Context,
-    language: Optional[str] = None,
-    domain: Optional[str] = None,
-    min_corrections: int = 3,
-    top_k: int = 20,
-) -> dict:
-    """
-    Scan the correction corpus and surface candidate rules for a style profile.
-
-    Retrieves human-corrected passages (stored via record_correction()) and extracts
-    the issue types that were most frequently corrected. Returns a list of candidate
-    rules and anti-patterns for the agent to present to the user — the user approves
-    or skips each one, then approved entries are merged via update_style_profile().
-
-    Typical workflow:
-        1. User has accumulated corrections via record_correction()
-        2. Call harvest_corrections_to_profile(profile_name="danilo-voice-pt", language="pt")
-        3. Present candidates to user: "Want to add these to your profile?"
-        4. For approved ones: call update_style_profile(name, new_rules=[...], new_anti_patterns=[...])
-
-    Args:
-        profile_name: The style profile to enrich (must already exist)
-        language: Filter to corrections in this language (en|pt). Omit for all.
-        domain: Filter to corrections in this domain. Omit for all.
-        min_corrections: Minimum human-corrected passages required before returning
-                         candidates (default 3). Prevents noise from tiny corpora.
-        top_k: Max corrections to analyse (default 20)
-
-    Returns:
-        {success, profile_name, corrections_found,
-         candidates: [{type, text, source_issue_type, example_corrected}],
-         insufficient_data, note}
-    """
-    from src.tools.style_profiles import harvest_corrections_to_profile as _harvest
-    return _harvest(
-        profile_name=profile_name,
-        language=language,
-        domain=domain,
-        min_corrections=min_corrections,
-        top_k=top_k,
-        client_id=_client_id(ctx),
-    )
-
-
-@mcp.tool()
-def search_style_profiles(
-    text: str,
-    ctx: Context,
-    top_k: int = 3,
-    channel: Optional[str] = None,
-) -> StyleProfileSearchResult:
-    """
-    Find saved style profiles most similar to a writing sample.
-
-    Use this to identify which saved writing style a piece of text most closely
-    matches — for example, before tagging a passage or adapting a draft.
-
-    Args:
-        text: A writing sample to compare against saved profiles
-        top_k: Number of results to return (default 3)
-        channel: Optional channel filter to narrow results
-                 (linkedin|facebook|email|report|proposal|general|...)
-
-    Returns:
-        {success, results: [{score, profile}], total}
-    """
-    from src.tools.style_profiles import search_style_profiles as _search
-    return _search(text=text, top_k=top_k, channel=channel, client_id=_client_id(ctx))
-
-
-@mcp.tool()
-def list_style_profiles(
-    ctx: Context,
-    channel: Optional[str] = None,
-    limit: int = 50,
-) -> dict:
-    """
-    List all saved writing style profiles, optionally filtered by channel.
-
-    Use this to browse available profiles before loading one, or to see
-    which channels have profiles defined.
-
-    Args:
-        channel: Filter to profiles tagged with a specific publishing surface
-                 (linkedin|facebook|instagram|twitter|whatsapp|tiktok|
-                  blog|newsletter|substack|email|report|proposal|
-                  executive-summary|tor|press-release|presentation|general)
-        limit: Max profiles to return (default 50)
-
-    Returns:
-        {success, profiles: [{name, description, channel, style_scores, created_at, document_id}], total}
-    """
-    from src.tools.style_profiles import list_style_profiles as _list
-    return _list(channel=channel, limit=limit, client_id=_client_id(ctx))
-
-
-@mcp.tool()
-def batch_add_passages(items: list[dict], ctx: Context) -> dict:
-    """
-    Add multiple writing passages in a single call.
-
-    Calls add_passage() for each item. Never raises — errors are collected per item.
-    Items missing the required 'text' field are recorded as failed.
-
-    Args:
-        items: List of passage dicts. Each dict supports the same fields as
-               add_passage(): text (required), doc_type, language, domain,
-               quality_notes, tags, source, style.
-
-    Returns:
-        {success: True, total, succeeded, failed, results: [per-item result with index]}
-    """
-    from src.tools.passages import batch_add_passages as _batch
-    return _batch(items=items, client_id=_client_id(ctx))
-
-
-@mcp.tool()
-def batch_add_terms(items: list[dict], ctx: Context) -> dict:
-    """
-    Add multiple terminology entries in a single call.
-
-    Calls add_term() for each item. Never raises — errors are collected per item.
-    Items missing the required 'preferred' field are recorded as failed.
-
-    Args:
-        items: List of term dicts. Each dict supports the same fields as
-               add_term(): preferred (required), avoid, domain, language,
-               why, example_bad, example_good.
-
-    Returns:
-        {success: True, total, succeeded, failed, results: [per-item result with index]}
-    """
-    from src.tools.terms import batch_add_terms as _batch
-    return _batch(items=items, client_id=_client_id(ctx))
-
-
-@mcp.tool()
-def export_library(collection: str, ctx: Context, output_format: str = "json") -> dict:
-    """
-    Export all points from a writing library collection.
-
-    Scrolls the entire Qdrant collection in batches of 1000 and returns
-    all payloads as JSON or CSV. Useful for backups, audits, or seeding
-    another environment.
-
-    Args:
-        collection: Logical alias — "passages", "terms", "style_profiles", or "rubrics" —
-                    or the literal Qdrant collection name.
-        output_format: Output format: "json" (default) or "csv".
-                       CSV stringifies list/dict fields automatically.
-
-    Returns:
-        {success, collection, count, format, data} on success,
-        where data is a list (json) or a CSV string (csv).
-        On failure: {success: False, error}.
-    """
-    from src.tools.export import export_library as _export
-    return _export(collection=collection, output_format=output_format, client_id=_client_id(ctx))
-
-
-@mcp.tool()
-def verify_claims(
-    text: str,
-    domain: str = "general",
-) -> VerifyClaimsResult:
-    """
-    Detect potential hallucinations by checking claim-bearing sentences for
-    explicit citation markers. Flags ghost stats (numbers without any source).
-
-    Use this when auditing a draft before submission, or when triaging AI-generated
-    prose for unsourced numeric claims. Ghost stats (verdict flag) should always
-    block publication. Fully self-contained — no external knowledge-base dependencies.
-
-    Extracts sentences that contain statistics, causal assertions, epistemic
-    verbs, citation placeholders, or country/prevalence keywords, then checks
-    each for APA or numeric citation markers.
-
-    Claim patterns detected:
-        - Numbers and percentages (e.g. "12.5%", "45 percent")
-        - Epistemic/causal verbs (shows that, indicates that, evidence suggests…)
-        - APA citations (Author Year) or numeric citations [N]
-        - Country/prevalence terms (in Mozambique, HIV prevalence, PLHIV…)
-
-    Verdict thresholds:
-        evidenced          — ≥80% of claims have citations
-        mixed              — 40–80% of claims have citations
-        unverified         — <40% of claims have citations
-        no_claims_detected — no claim-bearing sentences found; overall_evidence_score
-                             is None and no verification was performed
-
-    Ghost stats are uncited claim sentences that contain a number or
-    percentage — high-risk hallucination candidates.
-
-    Args:
-        text: The passage or document section to analyse
-        domain: Thematic domain for domain-specific claim pattern augmentation.
-                Valid values: "general", "finance", "governance", "climate",
-                "m-and-e", "org", "health". Unknown values fall back to general patterns.
-
-    Returns:
-        overall_evidence_score (0–1 or None), verdict (evidenced|mixed|unverified|no_claims_detected),
-        total_claims, verified_count, and per-claim results with ghost_stat flag.
-    """
-    from src.tools.evidence import verify_claims as _verify
-    return _verify(text=text, domain=domain)
-
-
-@mcp.tool()
-def score_evidence_density(text: str, domain: str = "general") -> dict:
-    """
-    Analyse the ratio of cited claim sentences to total claim sentences,
-    without calling any external search APIs.
-
-    Use this for a fast, offline check of how well-evidenced a document is
-    before running the more thorough verify_claims tool.
-
-    Claim detection uses the same patterns as verify_claims:
-        - Numbers and percentages
-        - Epistemic verbs and causal assertions
-        - APA or numeric citation markers
-        - Country/prevalence keywords
-
-    Citation detection looks for explicit markers:
-        - APA style: (Author, YYYY) or (Author et al. YYYY)
-        - Numeric style: [N]
-
-    Verdict thresholds:
-        well-evidenced        — cited/claims ≥ 0.6
-        partially-evidenced   — cited/claims 0.3–0.6
-        under-evidenced       — cited/claims < 0.3
-
-    Args:
-        text: The passage or document section to analyse
-        domain: Thematic domain for domain-specific claim pattern augmentation.
-                Valid values: "general", "finance", "governance", "climate",
-                "m-and-e", "org", "health". Unknown values fall back to general patterns.
-
-    Returns:
-        total_sentences, claim_sentences, cited_sentences, evidence_density (0–1),
-        verdict (well-evidenced|partially-evidenced|under-evidenced), domain, and
-        a recommendation string with actionable guidance.
-    """
-    from src.tools.evidence import score_evidence_density as _score
-    return _score(text=text, domain=domain)
-
-
-@mcp.tool()
-def add_rubric_criterion(
-    ctx: Context,
-    framework: str,
-    section: str,
-    criterion: str,
-    weight: float = 1.0,
-    red_flags: Optional[List[str]] = None,
-    note: str = "",
-) -> dict:
-    """
-    **Admin only** for direct writes; non-admins are auto-routed to the review queue.
-    Store an evaluation criterion in the rubric library.
-
-    Admins write directly to the shared rubric collection (routed_to="library").
-    Non-admin callers are routed to the moderation queue (routed_to="queue").
-
-    Use this to build up evaluation criteria for any framework — donor proposals
-    (usaid, undp, global-fund), client deliverables (lambda, oca-2025), or
-    internal standards (ds-moz-editorial). Score later with score_against_rubric().
-
-    Args:
-        framework: Evaluation framework slug — any lowercase slug (e.g. "usaid", "undp", "lambda", "oca-2025")
-        section: Document section name (e.g. "technical-approach", "sustainability", "m-and-e")
-        criterion: The criterion description (what evaluators look for)
-        weight: Relative importance 0.1–2.0 (default 1.0). Higher = more important criterion.
-        red_flags: Phrases or patterns that evaluators penalise (optional)
-        note: Optional free-text note stored with queued contributions (non-admin only)
-
-    Returns:
-        {success, routed_to: "library"|"queue", ...} — shape varies by route.
-    """
-    caller = _client_id(ctx)
-    if _require_admin(ctx) is None:
-        from src.tools.rubrics import add_rubric_criterion as _add
-        result = _add(framework=framework, section=section, criterion=criterion, weight=weight, red_flags=red_flags)
-        if result.get("success"):
-            result["routed_to"] = "library"
-        return result
-    from src.tools.contributions import contribute_rubric as _contribute
-    result = _contribute(
-        framework=framework,
-        section=section,
-        criterion=criterion,
-        contributed_by=caller,
-        weight=weight,
-        red_flags=red_flags,
-        note=note,
-    )
-    if result.get("success"):
-        _notify_contribution(result.get("contribution_id", ""), "rubrics", f"{framework}/{section}", caller)
-        result["routed_to"] = "queue"
-    return result
-
-
-@mcp.tool()
-def score_against_rubric(
-    text: str,
-    framework: str,
-    section: Optional[str] = None,
-    top_k: int = 5,
-    doc_context: Optional[str] = None,
-) -> RubricScoreResult:
-    """
-    Score a document section against stored evaluation criteria for a given framework.
-
-    Use this when pre-screening a proposal or report against donor rubrics before
-    submission (USAID, UNDP, Global Fund, EU, or custom frameworks). Retrieves the
-    most relevant criteria, computes a weighted semantic similarity score, and
-    returns a strong/adequate/weak verdict.
-
-    Args:
-        text: Document section to score
-        framework: Evaluation framework slug to filter criteria (e.g. "usaid", "lambda", "oca-2025")
-        section: Optional section filter (e.g. "technical-approach"). If omitted, all sections are used.
-        top_k: Number of criteria to match (default 5)
-        doc_context: Optional free-text context about the document type (e.g. "annual report"). Not stored — informational only.
-
-    Returns:
-        {success, framework, section, text_length, criteria_matched, overall_score,
-         verdict (strong|adequate|weak), criteria: [...], doc_context}
-        Verdict: strong ≥0.7 | adequate 0.5–0.7 | weak <0.5
-        Returns {success: False, error} if framework is empty or no criteria found.
-    """
-    from src.tools.rubrics import score_against_rubric as _score
-    return _score(text=text, framework=framework, section=section, top_k=top_k, doc_context=doc_context)
-
-
-@mcp.tool()
-def list_rubric_frameworks() -> dict:
-    """
-    Return all frameworks that have at least one criterion stored in the rubric library.
-
-    Use this to see which frameworks are ready for rubric scoring before calling
-    score_against_rubric().
-
-    Returns:
-        {success, frameworks: [{framework, criterion_count}], total_frameworks, total_criteria}
-        Frameworks are sorted alphabetically.
-    """
-    from src.tools.rubrics import list_rubric_frameworks as _list
-    return _list()
-
-
-@mcp.tool()
-def add_template(
-    ctx: Context,
-    framework: str,
-    doc_type: str,
-    sections: List[dict],
-    note: str = "",
-) -> dict:
-    """
-    **Admin only** for direct writes; non-admins are auto-routed to the review queue.
-    Store a document template (list of required sections) for a framework and document type.
-
-    Admins write directly to the shared template collection (routed_to="library").
-    Non-admin callers are routed to the moderation queue (routed_to="queue").
-
-    Use this to define the expected structure of documents for any framework — donor proposals
-    (usaid, undp), client deliverables (lambda, oca-2025), or internal standards. Once stored,
-    use check_structure() to verify a draft covers all required sections.
-
-    Args:
-        framework: Evaluation framework slug — any lowercase slug (e.g. "undp", "lambda", "ds-moz")
-        doc_type: Document type — must be one of the valid doc_types (see registry)
-        sections: List of section dicts. Each must have:
-                  - name (str): Section name (e.g. "Executive Summary")
-                  - description (str): What this section should contain
-                  - required (bool, optional): Whether mandatory (default True)
-                  - order (int, optional): Expected position 1-based (default = list index + 1)
-        note: Optional free-text note stored with queued contributions (non-admin only)
-
-    Returns:
-        {success, routed_to: "library"|"queue", ...} — shape varies by route.
-    """
-    caller = _client_id(ctx)
-    if _require_admin(ctx) is None:
-        from src.tools.templates import add_template as _add
-        result = _add(framework=framework, doc_type=doc_type, sections=sections)
-        if result.get("success"):
-            result["routed_to"] = "library"
-        return result
-    from src.tools.contributions import contribute_template as _contribute
-    result = _contribute(
-        framework=framework,
-        doc_type=doc_type,
-        sections=sections,
-        contributed_by=caller,
-        note=note,
-    )
-    if result.get("success"):
-        _notify_contribution(result.get("contribution_id", ""), "templates", f"{framework}/{doc_type}", caller)
-        result["routed_to"] = "queue"
-    return result
-
-
-@mcp.tool()
-def check_structure(
-    text: str,
-    framework: str,
-    doc_type: str,
-) -> StructureCheckResult:
-    """
-    Check whether a document draft covers all required sections from the stored template.
-
-    Use this when a draft needs a structural completeness check — before review,
-    submission, or as a quick TOC audit. Retrieves the stored template for the
-    framework+doc_type pair and evaluates each section's presence in the draft
-    using semantic similarity (with keyword fallback).
-
-    Args:
-        text: The document draft text to check
-        framework: Evaluation framework slug (e.g. "undp", "lambda", "ds-moz")
-        doc_type: Document type — must be one of the valid doc_types (see registry)
-
-    Returns:
-        {success, framework, doc_type, template_document_id, total_sections, required_sections,
-         present_count, partial_count, missing_count, verdict, sections, missing_required}
-        verdict is "complete" (0 missing required) or "incomplete" (>0 missing required)
-        Each section entry includes: name, required, status (present|partial|missing), coverage_score
-    """
-    from src.tools.templates import check_structure as _check
-    return _check(text=text, framework=framework, doc_type=doc_type)
-
-
-@mcp.tool()
-def list_templates() -> dict:
-    """
-    Return all stored document templates.
-
-    Use this to see which framework+doc_type combinations have templates stored,
-    before calling check_structure().
-
-    Returns:
-        {success, templates: [{framework, doc_type, section_count, document_id}], total}
-        Sorted alphabetically by framework then doc_type.
-    """
-    from src.tools.templates import list_templates as _list
-    return _list()
-
-
-@mcp.tool()
-def score_voice_consistency(
-    sections: List[str],
-    profile_name: Optional[str] = None,
-    top_k_profile: int = 1,
-) -> dict:
-    """
-    Measure how consistently a list of text sections share a voice/style.
-
-    Use this when reviewing a multi-author draft (proposal chapters, merged sections)
-    for voice drift, or when validating that a ghost-written section matches a saved
-    author profile.
-
-    Given 2–20 sections (e.g. proposal chapters written by different authors),
-    computes pairwise similarity between sections and optionally scores each
-    section against a saved style profile.
-
-    Args:
-        sections: List of text sections to compare (2–20 items required)
-        profile_name: Saved style profile name to compare against (e.g. "danilo-voice-pt").
-                      If omitted, sections are compared to each other only.
-        top_k_profile: How many top profile matches to return when profile_name is None (default 1).
-
-    Returns:
-        {
-            success, section_count,
-            inter_section_consistency (0–1, higher = more consistent),
-            consistency_verdict (consistent ≥0.7 | moderate 0.5–0.7 | inconsistent <0.5),
-            profile_name, profile_consistency (None if no profile),
-            profile_verdict (on-voice ≥0.65 | near-voice 0.45–0.65 | off-voice <0.45 | None),
-            sections: [{index, preview, drift_score, profile_score}],
-            highest_drift_section (index of most drifted section),
-            scoring_method (embedding | fallback)
-        }
-    """
-    from src.tools.consistency import score_voice_consistency as _score
-    return _score(sections=sections, profile_name=profile_name, top_k_profile=top_k_profile)
-
-
-@mcp.tool()
-def detect_authorship_shift(
-    text: str,
-    min_segment_length: int = 100,
-) -> dict:
-    """
-    Detect segments in a document that are stylistically different from the majority.
-
-    Splits the text on double newlines, embeds each segment, and flags segments
-    whose deviation from the centroid exceeds mean + 1.5 × std — indicating a
-    possible change of author or voice.
-
-    Requires at least 3 segments after filtering by min_segment_length.
-
-    Args:
-        text: Full document text to analyse
-        min_segment_length: Minimum characters per segment (default 100)
-
-    Returns:
-        {
-            success, total_segments, mean_deviation, std_deviation,
-            shifted_segments: [{index, preview, deviation, z_score}],
-            shift_detected (True if any shifted segments found),
-            scoring_method (embedding | fallback)
-        }
-        Returns {success: False, error} if fewer than 3 segments found.
-
-    Note: Shift detection becomes statistically unreliable with fewer than 5 segments.
-    With exactly 3 segments, the 1.5×std threshold may exceed the maximum possible
-    deviation, causing real shifts to go undetected. Prefer 5+ segments for reliable
-    results.
-    """
-    from src.tools.consistency import detect_authorship_shift as _detect
-    return _detect(text=text, min_segment_length=min_segment_length)
 
 
 @mcp.tool()
@@ -1380,37 +325,27 @@ def score_writing_patterns(
     """
     Score text against craft patterns. Single entry point for all five scoring modes.
 
-    Use this to detect AI-writing tells, semantic overlap with known-AI passages, or
-    craft issues in poetry/song/fiction drafts — dispatch via `mode`.
-
     Modes:
-        ai           — Known AI prose patterns (connectors, hollow intensifiers, em-dash intercalation,
-                       passive voice, paragraph length, discursive deficit, etc.).
-                       doc_type: concept-note|full-proposal|eoi|executive-summary|general|annual-report|
-                                 monitoring-report|financial-report|assessment|tor|governance-review (default: general)
-        semantic-ai  — Embedding-similarity to the user's ai-corrected vs human-corrected corpus.
-                       Requires record_correction() calls to build the corpus first.
-                       Uses top_k for neighbours per sub-corpus. Ignores doc_type/threshold/language.
-        poetry       — Poem-specific craft (rhyme, meter, stanza consistency, line-ending clichés, etc.).
-                       doc_type: haiku|sonnet|free-verse|villanelle|spoken-word (default: free-verse)
-        song         — Lyric-specific craft (verse/chorus structure, hook repetition, singability, etc.).
-                       doc_type: pop-song|ballad|rap-verse|hymn|jingle (default: pop-song)
-        fiction      — Prose-fiction craft (show-vs-tell, dialogue tags, adverb overload, purple prose).
-                       doc_type: novel-chapter|short-story|flash-fiction|screenplay|creative-nonfiction
-                                 (default: short-story)
+        ai           — Rule-based AI prose patterns. doc_type: concept-note|full-proposal|eoi|
+                       executive-summary|general|annual-report|monitoring-report|financial-report|
+                       assessment|tor|governance-review (default: general)
+        semantic-ai  — Embedding similarity to user's ai-corrected vs human-corrected corpus.
+                       Uses top_k. Ignores doc_type/threshold/language.
+        poetry       — Poem craft. doc_type: haiku|sonnet|free-verse|villanelle|spoken-word
+        song         — Lyric craft. doc_type: pop-song|ballad|rap-verse|hymn|jingle
+        fiction      — Prose-fiction craft. doc_type: novel-chapter|short-story|flash-fiction|
+                       screenplay|creative-nonfiction
 
     Args:
         text: The text to score
         mode: ai|semantic-ai|poetry|song|fiction
         language: "en", "pt", or "auto" (ignored by semantic-ai)
-        doc_type: Mode-specific document/form type (see per-mode defaults above)
-        threshold: Per-category score above which a category is flagged (ignored by semantic-ai)
+        doc_type: Mode-specific document/form type
+        threshold: Per-category flag threshold (ignored by semantic-ai)
         top_k: Neighbours per sub-corpus (semantic-ai only)
 
     Returns:
-        Mode-specific result dict. See the underlying helpers for shape.
-        For ai/poetry/song/fiction: overall_score, verdict, per-category scores, counts, doc_type.
-        For semantic-ai: likelihood, verdict, mean-similarity stats, sample counts, method.
+        Mode-specific dict. Invalid mode → {"success": False, "error": ...}.
     """
     if mode == "semantic-ai":
         from src.tools.ai_patterns import score_semantic_ai_likelihood as _score
@@ -1434,40 +369,678 @@ def score_writing_patterns(
 
 
 @mcp.tool()
-def suggest_alternatives(
-    word: str,
-    language: str = "en",
-    domain: str = "general",
-    context_sentence: Optional[str] = None,
-    top_k: int = 5,
-) -> dict:
+def verify_claims(text: str, domain: str = "general") -> VerifyClaimsResult:
     """
-    Look up a word in the vocabulary thesaurus and return rich alternatives.
+    Detect potential hallucinations by checking claim-bearing sentences for citation markers.
 
-    Returns definition, register, meaning nuances, collocations, and why the word sounds AI-generated.
-    Falls back to search_terms if the word is not in the thesaurus.
-    Use this when drafting or reviewing text and you want to replace an overused or AI-sounding word.
+    Flags ghost stats (numbers without any source) — always a blocker. Fully self-contained.
+
+    Verdicts: evidenced (≥80% cited) | mixed (40–80%) | unverified (<40%) | no_claims_detected.
 
     Args:
-        word: The word to look up (e.g. "leverage", "robust", "ensure")
-        language: Language of the word: en|pt
-        domain: Thematic domain: srhr|governance|climate|general|m-and-e|health|finance|org
-        context_sentence: Optional sentence where the word appears (reserved for future semantic re-ranking)
-        top_k: Maximum alternatives to return (default 5)
+        text: The passage to analyse
+        domain: general|finance|governance|climate|m-and-e|org|health
 
     Returns:
-        definition, why_avoid, alternatives (with word, meaning_nuance, register, when_to_use),
-        collocations, example_bad, example_good. found_in_thesaurus flag indicates source.
+        overall_evidence_score, verdict, total_claims, verified_count, per-claim ghost_stat flags.
     """
-    from src.tools.thesaurus import suggest_alternatives as _suggest
-    return _suggest(word=word, language=language, domain=domain,
-                    context_sentence=context_sentence, top_k=top_k)
+    from src.tools.evidence import verify_claims as _verify
+    return _verify(text=text, domain=domain)
 
 
 @mcp.tool()
-def add_thesaurus_entry(
+def score_evidence_density(text: str, domain: str = "general") -> dict:
+    """
+    Offline ratio of cited claim sentences to total claim sentences.
+
+    Verdicts: well-evidenced (≥0.6) | partially-evidenced (0.3–0.6) | under-evidenced (<0.3).
+
+    Args:
+        text: The passage to analyse
+        domain: general|finance|governance|climate|m-and-e|org|health
+
+    Returns:
+        total_sentences, claim_sentences, cited_sentences, evidence_density, verdict, recommendation.
+    """
+    from src.tools.evidence import score_evidence_density as _score
+    return _score(text=text, domain=domain)
+
+
+@mcp.tool()
+def score_against_rubric(
+    text: str,
+    framework: str,
+    section: Optional[str] = None,
+    top_k: int = 5,
+    doc_context: Optional[str] = None,
+) -> RubricScoreResult:
+    """
+    Score a document section against stored rubric criteria for a framework.
+
+    Verdict: strong (≥0.7) | adequate (0.5–0.7) | weak (<0.5).
+
+    Args:
+        text: Document section to score
+        framework: Framework slug (e.g. "usaid", "undp", "lambda")
+        section: Optional section filter (e.g. "technical-approach")
+        top_k: Number of criteria to match (default 5)
+        doc_context: Optional free-text document-type context
+
+    Returns:
+        overall_score, verdict, matched criteria, doc_context.
+    """
+    from src.tools.rubrics import score_against_rubric as _score
+    return _score(text=text, framework=framework, section=section, top_k=top_k, doc_context=doc_context)
+
+
+@mcp.tool()
+def check_structure(text: str, framework: str, doc_type: str) -> StructureCheckResult:
+    """
+    Check whether a document covers all required sections from the stored template.
+
+    Args:
+        text: The document text to check
+        framework: Framework slug (e.g. "undp", "lambda", "ds-moz")
+        doc_type: Document type (see registry)
+
+    Returns:
+        verdict (complete|incomplete), per-section status (present|partial|missing), counts.
+    """
+    from src.tools.templates import check_structure as _check
+    return _check(text=text, framework=framework, doc_type=doc_type)
+
+
+@mcp.tool()
+def score_voice_consistency(
+    sections: List[str],
+    profile_name: Optional[str] = None,
+    top_k_profile: int = 1,
+) -> dict:
+    """
+    Measure voice/style consistency across 2–20 text sections.
+
+    Pairwise similarity + optional comparison to saved style profile.
+
+    Args:
+        sections: List of text sections to compare (2–20 items)
+        profile_name: Saved profile name (e.g. "danilo-voice-pt"), optional
+        top_k_profile: Top profile matches to return when profile_name=None (default 1)
+
+    Returns:
+        inter_section_consistency, consistency_verdict, profile_consistency, profile_verdict,
+        per-section drift_score / profile_score, highest_drift_section.
+    """
+    from src.tools.consistency import score_voice_consistency as _score
+    return _score(sections=sections, profile_name=profile_name, top_k_profile=top_k_profile)
+
+
+@mcp.tool()
+def detect_authorship_shift(text: str, min_segment_length: int = 100) -> dict:
+    """
+    Detect segments stylistically different from the majority (possible author change).
+
+    Requires ≥3 segments after filtering. Prefer 5+ segments for statistical reliability.
+
+    Args:
+        text: Full document text
+        min_segment_length: Minimum characters per segment (default 100)
+
+    Returns:
+        mean_deviation, std_deviation, shifted_segments (index, preview, z_score), shift_detected.
+    """
+    from src.tools.consistency import detect_authorship_shift as _detect
+    return _detect(text=text, min_segment_length=min_segment_length)
+
+
+@mcp.tool()
+def flag_vocabulary(
+    text: str,
+    language: str = "en",
+    domain: str = "general",
+) -> VocabularyFlagResult:
+    """
+    Scan text for AI-pattern vocabulary headwords in the thesaurus.
+
+    Args:
+        text: The text to scan
+        language: en|pt
+        domain: srhr|governance|climate|general|m-and-e|health|finance|org
+
+    Returns:
+        verdict (clean|review|ai-sounding), flagged_count, flagged entries with alternatives_preview.
+    """
+    from src.tools.thesaurus import flag_vocabulary as _flag
+    return _flag(text=text, language=language, domain=domain)
+
+
+# ===========================================================================
+# 2. MERGED CRUD / MANAGE (6 tools)
+# ===========================================================================
+
+@mcp.tool()
+def manage_passage(
+    action: str,
     ctx: Context,
-    headword: str,
+    # add/update fields
+    document_id: Optional[str] = None,
+    text: Optional[str] = None,
+    doc_type: Optional[str] = None,
+    language: Optional[str] = None,
+    domain: Optional[str] = None,
+    quality_notes: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+    source: Optional[str] = None,
+    style: Optional[List[str]] = None,
+    rubric_section: Optional[str] = None,
+    # batch add
+    items: Optional[List[dict]] = None,
+    # correction
+    original: Optional[str] = None,
+    corrected: Optional[str] = None,
+    issue_type: Optional[str] = None,
+) -> dict:
+    """
+    Manage exemplary writing passages (per-user collection).
+
+    Actions:
+        add        — Store a passage. Pass `text` (single) OR `items` (list of dicts).
+                     Single fields: text, doc_type, language, domain, quality_notes, tags,
+                     source, style, rubric_section.
+        update     — Modify fields of an existing passage. Requires `document_id`.
+        delete     — Remove a passage by `document_id`.
+        correction — Store an original/corrected pair (both tagged for later semantic-ai scoring).
+                     Requires: original, corrected, issue_type (e.g. "ai-patterns", "passive-voice").
+
+    Args:
+        action: add|update|delete|correction
+        document_id: Required for update/delete
+        text, doc_type, language, domain, quality_notes, tags, source, style, rubric_section:
+            add/update fields (all optional on update; merged with existing metadata)
+        items: For action="add" batch — list of passage dicts
+        original, corrected, issue_type: For action="correction"
+
+    Returns:
+        Action-specific dict. See underlying passage tool for exact shape.
+    """
+    client_id = _client_id(ctx)
+
+    if action == "add":
+        if items is not None:
+            from src.tools.passages import batch_add_passages as _batch
+            return _batch(items=items, client_id=client_id)
+        if text is None:
+            return {"success": False, "error": "action='add' requires 'text' or 'items'"}
+        from src.tools.passages import add_passage as _add
+        return _add(
+            text=text, doc_type=doc_type or "general", language=language or "en",
+            domain=domain or "general", quality_notes=quality_notes or "",
+            tags=tags or [], source=source or "manual",
+            style=style or [], rubric_section=rubric_section,
+            client_id=client_id,
+        )
+
+    if action == "update":
+        if not document_id:
+            return {"success": False, "error": "action='update' requires 'document_id'"}
+        from src.tools.passages import update_passage as _update
+        return _update(
+            document_id=document_id,
+            text=text, doc_type=doc_type, language=language, domain=domain,
+            quality_notes=quality_notes, tags=tags, source=source, style=style,
+            client_id=client_id,
+        )
+
+    if action == "delete":
+        if not document_id:
+            return {"success": False, "error": "action='delete' requires 'document_id'"}
+        from src.tools.passages import delete_passage as _delete
+        return _delete(document_id=document_id, client_id=client_id)
+
+    if action == "correction":
+        if not (original and corrected and issue_type):
+            return {"success": False, "error": "action='correction' requires 'original', 'corrected', 'issue_type'"}
+        from src.tools.passages import record_correction as _record
+        return _record(
+            original=original, corrected=corrected, issue_type=issue_type,
+            doc_type=doc_type or "general", language=language or "en",
+            domain=domain or "general", source=source or "manual",
+            client_id=client_id,
+        )
+
+    return {"success": False, "error": f"Invalid action '{action}'. Must be one of: add, update, delete, correction"}
+
+
+@mcp.tool()
+def manage_term(
+    action: str,
+    ctx: Context,
+    # add/update fields
+    document_id: Optional[str] = None,
+    preferred: Optional[str] = None,
+    avoid: Optional[str] = None,
+    domain: Optional[str] = None,
+    language: Optional[str] = None,
+    why: Optional[str] = None,
+    example_bad: Optional[str] = None,
+    example_good: Optional[str] = None,
+    # share routing (add only)
+    share: bool = False,
+    note: str = "",
+    # batch
+    items: Optional[List[dict]] = None,
+) -> dict:
+    """
+    Manage terminology entries. add routes share→library|queue|personal based on ADMIN_CLIENT_ID.
+
+    Actions:
+        add    — Add a term. Pass `preferred` (single) OR `items` (list).
+                 share=False (default): writes to caller's personal dictionary.
+                 share=True + admin: writes to shared library (routed_to="library").
+                 share=True + non-admin: queues for moderation (routed_to="queue").
+        update — Modify fields of an existing term. Requires `document_id`.
+        delete — Remove a term by `document_id`.
+
+    Args:
+        action: add|update|delete
+        document_id: Required for update/delete
+        preferred, avoid, domain, language, why, example_bad, example_good: Term fields
+        share: For action="add" — target shared library (admin) or queue (non-admin)
+        note: Optional moderator note (queued contributions only)
+        items: For action="add" batch — list of term dicts
+
+    Returns:
+        Action-specific dict. add includes routed_to: "personal"|"library"|"queue".
+    """
+    client_id = _client_id(ctx)
+
+    if action == "add":
+        if items is not None:
+            from src.tools.terms import batch_add_terms as _batch
+            return _batch(items=items, client_id=client_id)
+        if not preferred:
+            return {"success": False, "error": "action='add' requires 'preferred' or 'items'"}
+
+        if not share:
+            from src.tools.terms import add_term as _add
+            result = _add(
+                preferred=preferred, avoid=avoid or "", domain=domain or "general",
+                language=language or "en", why=why or "",
+                example_bad=example_bad or "", example_good=example_good or "",
+                client_id=client_id,
+            )
+            if result.get("success"):
+                result["routed_to"] = "personal"
+            return result
+
+        # share=True
+        if _require_admin(ctx) is None:
+            from uuid import uuid4
+            from src.tools.collections import get_core_collection_names
+            from src.tools.registry import VALID_DOMAINS
+            dom = domain or "general"
+            if dom not in VALID_DOMAINS:
+                return {"success": False, "error": f"Invalid domain '{dom}'. Must be one of: {sorted(VALID_DOMAINS)}"}
+            if not preferred or not preferred.strip():
+                return {"success": False, "error": "preferred term cannot be empty"}
+            try:
+                from kbase.vector.sync_indexing import index_document
+            except ImportError:
+                return {"success": False, "error": "kbase indexing unavailable"}
+            collection = get_core_collection_names().get("terms_shared", "writing_terms_shared")
+            document_id_new = str(uuid4())
+            content_parts = [
+                f"Preferred term: {preferred}",
+                f"Avoid: {avoid}" if avoid else "",
+                f"Why: {why}" if why else "",
+                f"Bad example: {example_bad}" if example_bad else "",
+                f"Good example: {example_good}" if example_good else "",
+                f"Domain: {dom}",
+                f"Language: {language or 'en'}",
+            ]
+            content = "\n".join(p for p in content_parts if p)
+            metadata = {
+                "client_id": "shared", "preferred": preferred, "avoid": avoid or "",
+                "domain": dom, "language": language or "en", "why": why or "",
+                "example_bad": example_bad or "", "example_good": example_good or "",
+                "entry_type": "term", "contributed_by": client_id,
+            }
+            try:
+                point_ids = index_document(
+                    collection_name=collection, document_id=document_id_new,
+                    title=preferred, content=content, metadata=metadata,
+                    context_mode="metadata",
+                )
+                return {
+                    "success": True, "document_id": document_id_new,
+                    "chunks_created": len(point_ids), "collection": collection,
+                    "routed_to": "library",
+                }
+            except Exception as e:
+                return {"success": False, "error": str(e)}
+
+        # share=True + non-admin → queue
+        from src.tools.contributions import contribute_term as _contribute
+        result = _contribute(
+            preferred=preferred, contributed_by=client_id, avoid=avoid or "",
+            domain=domain or "general", language=language or "en",
+            why=why or "", example_bad=example_bad or "",
+            example_good=example_good or "", note=note,
+        )
+        if result.get("success"):
+            _notify_contribution(result.get("contribution_id", ""), "terms", preferred, client_id)
+            result["routed_to"] = "queue"
+        return result
+
+    if action == "update":
+        if not document_id:
+            return {"success": False, "error": "action='update' requires 'document_id'"}
+        from src.tools.terms import update_term as _update
+        return _update(
+            document_id=document_id,
+            preferred=preferred, avoid=avoid, domain=domain, language=language,
+            why=why, example_bad=example_bad, example_good=example_good,
+            client_id=client_id,
+        )
+
+    if action == "delete":
+        if not document_id:
+            return {"success": False, "error": "action='delete' requires 'document_id'"}
+        from src.tools.terms import delete_term as _delete
+        return _delete(document_id=document_id, client_id=client_id)
+
+    return {"success": False, "error": f"Invalid action '{action}'. Must be one of: add, update, delete"}
+
+
+@mcp.tool()
+def manage_style_profile(
+    action: str,
+    ctx: Context,
+    # common
+    name: Optional[str] = None,
+    channel: Optional[str] = None,
+    # save
+    style_scores: Optional[dict] = None,
+    rules: Optional[list] = None,
+    anti_patterns: Optional[list] = None,
+    sample_excerpts: Optional[list] = None,
+    description: Optional[str] = None,
+    source_documents: Optional[list] = None,
+    # save: blend weight for upsert
+    score_weight: float = 0.3,
+    # search
+    text: Optional[str] = None,
+    top_k: int = 3,
+    # list
+    limit: int = 50,
+    # harvest-corrections
+    language: Optional[str] = None,
+    domain: Optional[str] = None,
+    min_corrections: int = 3,
+) -> dict:
+    """
+    Manage writing style profiles (per-user, channel-tagged).
+
+    Actions:
+        save                 — Upsert a profile by `name`. If it exists, blends new evidence
+                               into the existing profile (score_weight = new share); otherwise
+                               creates it. Requires: name, style_scores, rules, anti_patterns,
+                               sample_excerpts.
+        load                 — Load by exact `name`.
+        search               — Find profiles similar to `text`. Optional `channel` filter.
+        list                 — List all profiles. Optional `channel` filter, `limit`.
+        harvest-corrections  — Scan correction corpus and surface candidate rules to merge
+                               into profile `name`. Returns candidates only — agent must
+                               re-save with manage_style_profile(action='save') after review.
+
+    Args:
+        action: save|load|search|list|harvest-corrections
+        name: Profile name (required by save/load/harvest-corrections)
+        channel: Publishing surface (linkedin|email|report|proposal|general|...)
+        style_scores, rules, anti_patterns, sample_excerpts, description, source_documents:
+            save fields
+        score_weight: save — blend weight for existing profile (default 0.3 = 30% new)
+        text: search — sample to compare
+        top_k: search — results count (default 3)
+        limit: list — max profiles (default 50)
+        language, domain, min_corrections: harvest-corrections filters
+
+    Returns:
+        Action-specific dict.
+    """
+    client_id = _client_id(ctx)
+
+    if action == "save":
+        if not name:
+            return {"success": False, "error": "action='save' requires 'name'"}
+        # upsert: check if profile exists, dispatch to save vs update
+        from src.tools.style_profiles import (
+            load_style_profile as _load,
+            save_style_profile as _save,
+            update_style_profile as _update,
+        )
+        existing = _load(name=name, client_id=client_id)
+        if existing.get("success"):
+            return _update(
+                name=name,
+                new_style_scores=style_scores,
+                new_rules=rules,
+                new_anti_patterns=anti_patterns,
+                new_sample_excerpts=sample_excerpts,
+                new_source_documents=source_documents,
+                description=description,
+                channel=channel,
+                score_weight=score_weight,
+                client_id=client_id,
+            )
+        # create
+        if style_scores is None or rules is None or anti_patterns is None or sample_excerpts is None:
+            return {"success": False, "error": "action='save' on new profile requires style_scores, rules, anti_patterns, sample_excerpts"}
+        return _save(
+            name=name,
+            style_scores=style_scores,
+            rules=rules,
+            anti_patterns=anti_patterns,
+            sample_excerpts=sample_excerpts,
+            description=description or "",
+            source_documents=source_documents or [],
+            channel=channel,
+            client_id=client_id,
+        )
+
+    if action == "load":
+        if not name:
+            return {"success": False, "error": "action='load' requires 'name'"}
+        from src.tools.style_profiles import load_style_profile as _load
+        return _load(name=name, client_id=client_id)
+
+    if action == "search":
+        if not text:
+            return {"success": False, "error": "action='search' requires 'text'"}
+        from src.tools.style_profiles import search_style_profiles as _search
+        return _search(text=text, top_k=top_k, channel=channel, client_id=client_id)
+
+    if action == "list":
+        from src.tools.style_profiles import list_style_profiles as _list
+        return _list(channel=channel, limit=limit, client_id=client_id)
+
+    if action == "harvest-corrections":
+        if not name:
+            return {"success": False, "error": "action='harvest-corrections' requires 'name' (profile_name)"}
+        from src.tools.style_profiles import harvest_corrections_to_profile as _harvest
+        return _harvest(
+            profile_name=name,
+            language=language,
+            domain=domain,
+            min_corrections=min_corrections,
+            top_k=top_k if top_k != 3 else 20,
+            client_id=client_id,
+        )
+
+    return {"success": False, "error": f"Invalid action '{action}'. Must be one of: save, load, search, list, harvest-corrections"}
+
+
+@mcp.tool()
+def search_thesaurus(
+    query: str,
+    rich: bool = False,
+    language: Optional[str] = None,
+    domain: Optional[str] = None,
+    top_k: int = 8,
+    context_sentence: Optional[str] = None,
+) -> dict:
+    """
+    Search the vocabulary thesaurus, optionally with rich alternatives lookup.
+
+    rich=False (default): Semantic search across thesaurus entries. Returns list of
+    matching entries with full metadata including alternatives.
+
+    rich=True: Word-lookup mode (former suggest_alternatives). Returns definition,
+    why-avoid, ranked alternatives with meaning_nuance/register/when_to_use, collocations.
+    Falls back to search_terms if `query` is not in the thesaurus. Use when
+    `query` is a single word you want to replace.
+
+    Args:
+        query: Search text, or the word to look up (rich=True)
+        rich: If True, return detailed alternatives for `query` as a headword
+        language: Filter: en|pt
+        domain: Filter: srhr|governance|climate|general|m-and-e|health|finance|org
+        top_k: Max results (default 8; alternatives default 5 in rich mode)
+        context_sentence: Optional sentence context (rich=True, reserved for future re-ranking)
+
+    Returns:
+        rich=False: list of matching entries
+        rich=True: definition, why_avoid, alternatives, collocations, found_in_thesaurus
+    """
+    if rich:
+        from src.tools.thesaurus import suggest_alternatives as _suggest
+        return _suggest(
+            word=query,
+            language=language or "en",
+            domain=domain or "general",
+            context_sentence=context_sentence,
+            top_k=top_k if top_k != 8 else 5,
+        )
+    from src.tools.thesaurus import search_thesaurus as _search
+    return _search(query=query, language=language, domain=domain, top_k=top_k)
+
+
+@mcp.tool()
+def manage_contributions(
+    action: str,
+    ctx: Context,
+    # list
+    status: str = "pending",
+    target: Optional[str] = None,
+    mine: bool = False,
+    limit: int = 50,
+    # review
+    contribution_id: Optional[str] = None,
+    review_action: Optional[str] = None,
+    rejection_reason: str = "",
+) -> dict:
+    """
+    Manage the contribution moderation queue.
+
+    Actions:
+        list   — List contributions. Admins see all; non-admins see only their own (mine enforced).
+                 Filters: status ∈ {pending, published, rejected, all}, target ∈ {terms, thesaurus,
+                 rubrics, templates}, mine (non-admins always True), limit.
+        review — **Admin only.** Publish or reject a pending contribution.
+                 Requires: contribution_id, review_action ∈ {publish, reject}.
+                 rejection_reason required when review_action='reject'.
+
+    Args:
+        action: list|review
+        status, target, mine, limit: list filters
+        contribution_id, review_action, rejection_reason: review fields
+
+    Returns:
+        Action-specific dict.
+    """
+    caller = _client_id(ctx)
+    admin_id = os.getenv("ADMIN_CLIENT_ID", "")
+    is_admin = bool(admin_id) and caller == admin_id
+
+    if action == "list":
+        from src.tools.contributions import list_contributions as _list
+        contributed_by = caller if (mine or not is_admin) else None
+        return _list(status=status, target=target, contributed_by=contributed_by, limit=limit)
+
+    if action == "review":
+        err = _require_admin(ctx)
+        if err:
+            return {"success": False, "error": err}
+        if not contribution_id or not review_action:
+            return {"success": False, "error": "action='review' requires 'contribution_id' and 'review_action'"}
+        from src.tools.contributions import review_contribution as _review
+        return _review(
+            contribution_id=contribution_id,
+            action=review_action,
+            reviewed_by=caller,
+            rejection_reason=rejection_reason,
+        )
+
+    return {"success": False, "error": f"Invalid action '{action}'. Must be one of: list, review"}
+
+
+@mcp.tool()
+def manage_library(
+    action: str,
+    ctx: Context,
+    # export
+    collection: Optional[str] = None,
+    output_format: str = "json",
+) -> dict:
+    """
+    Library-level operations.
+
+    Actions:
+        stats   — Return point counts for the caller's Qdrant collections.
+        export  — Export a collection to JSON or CSV. Requires `collection` alias
+                  ("passages", "terms", "style_profiles", "rubrics") or literal name.
+
+    Args:
+        action: stats|export
+        collection: For action="export" — collection alias or literal Qdrant name
+        output_format: For action="export" — "json" (default) or "csv"
+
+    Returns:
+        Action-specific dict.
+    """
+    client_id = _client_id(ctx)
+
+    if action == "stats":
+        from src.tools.collections import get_stats
+        return get_stats(client_id=client_id)
+
+    if action == "export":
+        if not collection:
+            return {"success": False, "error": "action='export' requires 'collection'"}
+        from src.tools.export import export_library as _export
+        return _export(collection=collection, output_format=output_format, client_id=client_id)
+
+    return {"success": False, "error": f"Invalid action '{action}'. Must be one of: stats, export"}
+
+
+# ===========================================================================
+# 3. ADMIN WRITES MERGED (1 tool)
+# ===========================================================================
+
+@mcp.tool()
+def admin_add(
+    kind: str,
+    ctx: Context,
+    # rubric
+    framework: Optional[str] = None,
+    section: Optional[str] = None,
+    criterion: Optional[str] = None,
+    weight: float = 1.0,
+    red_flags: Optional[List[str]] = None,
+    # template
+    doc_type: Optional[str] = None,
+    sections: Optional[List[dict]] = None,
+    # thesaurus
+    headword: Optional[str] = None,
     language: str = "en",
     domain: str = "general",
     definition: str = "",
@@ -1479,193 +1052,139 @@ def add_thesaurus_entry(
     example_bad: str = "",
     example_good: str = "",
     source: str = "manual",
+    # common
     note: str = "",
 ) -> dict:
     """
-    **Admin only** for direct writes; non-admins are auto-routed to the review queue.
-    Add an AI-pattern word to the vocabulary thesaurus.
+    **Admin-only direct writes; non-admins auto-route to the moderation queue.**
 
-    Admins write directly to the shared thesaurus (routed_to="library").
-    Non-admin callers are routed to the moderation queue (routed_to="queue") and the
-    entry becomes visible to all users only after an admin reviews it via
-    review_contribution().
+    Add an entry to one of the three shared/core collections. `kind` selects the schema.
+
+    Kinds:
+        rubric     — Store a rubric criterion. Requires: framework, section, criterion.
+                     Optional: weight (default 1.0), red_flags.
+        template   — Store a document template. Requires: framework, doc_type, sections
+                     (list of {name, description, required?, order?} dicts).
+        thesaurus  — Store a thesaurus headword. Requires: headword.
+                     Optional: language, domain, definition, part_of_speech, register,
+                     alternatives, collocations, why_avoid, example_bad, example_good, source.
+
+    Non-admin callers are routed to the moderation queue (routed_to="queue"); admins write
+    directly (routed_to="library"). Pass `note` to leave a message for moderators when queued.
 
     Args:
-        headword: The word to flag (e.g. "leverage")
-        language: Language: en|pt
-        domain: Thematic domain: srhr|governance|climate|general|m-and-e|health|finance|org
-        definition: Concise definition of the headword
-        part_of_speech: verb | noun | adjective | adverb | phrase
-        register: formal | neutral | informal | institutional | academic
-        alternatives: List of dicts: [{word, meaning_nuance, register, when_to_use}]
-        collocations: Common collocations to flag (e.g. ["robust framework"])
-        why_avoid: Why this word sounds AI-generated or overused
-        example_bad: Sentence using the headword poorly
-        example_good: Sentence using a preferred alternative
-        source: Origin: manual|dicionario-aberto|wordnik|harvested (admin path only)
-        note: Optional free-text note stored with queued contributions (non-admin only)
+        kind: rubric|template|thesaurus
+        framework, section, criterion, weight, red_flags: rubric fields
+        framework, doc_type, sections: template fields
+        headword, language, domain, definition, part_of_speech, register, alternatives,
+            collocations, why_avoid, example_bad, example_good, source: thesaurus fields
+        note: Optional moderator note (queued contributions only)
 
     Returns:
-        {success, routed_to: "library"|"queue", ...} — shape varies by route.
+        {success, routed_to: "library"|"queue", ...} — shape varies by kind and route.
     """
     caller = _client_id(ctx)
-    if _require_admin(ctx) is None:
-        from src.tools.thesaurus import add_thesaurus_entry as _add
-        result = _add(headword=headword, language=language, domain=domain,
-                      definition=definition, part_of_speech=part_of_speech,
-                      register=register, alternatives=alternatives or [],
-                      collocations=collocations or [], why_avoid=why_avoid,
-                      example_bad=example_bad, example_good=example_good, source=source)
+    is_admin = _require_admin(ctx) is None
+
+    if kind == "rubric":
+        if not (framework and section and criterion):
+            return {"success": False, "error": "kind='rubric' requires 'framework', 'section', 'criterion'"}
+        if is_admin:
+            from src.tools.rubrics import add_rubric_criterion as _add
+            result = _add(framework=framework, section=section, criterion=criterion,
+                          weight=weight, red_flags=red_flags)
+            if result.get("success"):
+                result["routed_to"] = "library"
+            return result
+        from src.tools.contributions import contribute_rubric as _contribute
+        result = _contribute(
+            framework=framework, section=section, criterion=criterion,
+            contributed_by=caller, weight=weight, red_flags=red_flags, note=note,
+        )
         if result.get("success"):
-            result["routed_to"] = "library"
+            _notify_contribution(result.get("contribution_id", ""), "rubrics", f"{framework}/{section}", caller)
+            result["routed_to"] = "queue"
         return result
-    from src.tools.contributions import contribute_thesaurus_entry as _contribute
-    result = _contribute(
-        headword=headword, language=language, domain=domain,
-        definition=definition, part_of_speech=part_of_speech,
-        register=register, alternatives=alternatives or [],
-        collocations=collocations or [], why_avoid=why_avoid,
-        example_bad=example_bad, example_good=example_good,
-        contributed_by=caller, note=note,
-    )
-    if result.get("success"):
-        _notify_contribution(result.get("contribution_id", ""), "thesaurus", headword, caller)
-        result["routed_to"] = "queue"
-    return result
+
+    if kind == "template":
+        if not (framework and doc_type and sections):
+            return {"success": False, "error": "kind='template' requires 'framework', 'doc_type', 'sections'"}
+        if is_admin:
+            from src.tools.templates import add_template as _add
+            result = _add(framework=framework, doc_type=doc_type, sections=sections)
+            if result.get("success"):
+                result["routed_to"] = "library"
+            return result
+        from src.tools.contributions import contribute_template as _contribute
+        result = _contribute(
+            framework=framework, doc_type=doc_type, sections=sections,
+            contributed_by=caller, note=note,
+        )
+        if result.get("success"):
+            _notify_contribution(result.get("contribution_id", ""), "templates", f"{framework}/{doc_type}", caller)
+            result["routed_to"] = "queue"
+        return result
+
+    if kind == "thesaurus":
+        if not headword:
+            return {"success": False, "error": "kind='thesaurus' requires 'headword'"}
+        if is_admin:
+            from src.tools.thesaurus import add_thesaurus_entry as _add
+            result = _add(
+                headword=headword, language=language, domain=domain,
+                definition=definition, part_of_speech=part_of_speech,
+                register=register, alternatives=alternatives or [],
+                collocations=collocations or [], why_avoid=why_avoid,
+                example_bad=example_bad, example_good=example_good, source=source,
+            )
+            if result.get("success"):
+                result["routed_to"] = "library"
+            return result
+        from src.tools.contributions import contribute_thesaurus_entry as _contribute
+        result = _contribute(
+            headword=headword, language=language, domain=domain,
+            definition=definition, part_of_speech=part_of_speech,
+            register=register, alternatives=alternatives or [],
+            collocations=collocations or [], why_avoid=why_avoid,
+            example_bad=example_bad, example_good=example_good,
+            contributed_by=caller, note=note,
+        )
+        if result.get("success"):
+            _notify_contribution(result.get("contribution_id", ""), "thesaurus", headword, caller)
+            result["routed_to"] = "queue"
+        return result
+
+    return {"success": False, "error": f"Invalid kind '{kind}'. Must be one of: rubric, template, thesaurus"}
 
 
-@mcp.tool()
-def search_thesaurus(
-    query: str,
-    language: Optional[str] = None,
-    domain: Optional[str] = None,
-    top_k: int = 8,
-) -> dict:
-    """
-    Semantic search across thesaurus entries.
+# ===========================================================================
+# 4. MCP RESOURCES (demoted from list_* tools)
+# ===========================================================================
 
-    Use to explore what AI-pattern words are stored, or to find entries
-    related to a concept (e.g. "governance vocabulary", "verbs for action").
-
-    Args:
-        query: What you are searching for
-        language: Filter by language: en|pt
-        domain: Filter by domain: srhr|governance|climate|general|m-and-e|health|finance|org
-        top_k: Number of results (default 8)
-
-    Returns:
-        List of matching entries with full metadata including alternatives
-    """
-    from src.tools.thesaurus import search_thesaurus as _search
-    return _search(query=query, language=language, domain=domain, top_k=top_k)
+@mcp.resource("writing-library://styles")
+def resource_styles() -> dict:
+    """Writing style labels with descriptions, grouped by category (14 labels, 4 categories)."""
+    from src.tools.styles import list_styles as _list
+    return _list()
 
 
-@mcp.tool()
-def flag_vocabulary(
-    text: str,
-    language: str = "en",
-    domain: str = "general",
-) -> VocabularyFlagResult:
-    """
-    Scan text for AI-pattern vocabulary headwords present in the thesaurus.
-
-    Use alongside score_writing_patterns(mode="ai") (which catches structural patterns)
-    to get lexical-level flagging. Returns flagged words with occurrence counts
-    and a preview of alternatives.
-
-    Args:
-        text: The text to scan
-        language: Language of the text: en|pt
-        domain: Thematic domain: srhr|governance|climate|general|m-and-e|health|finance|org
-
-    Returns:
-        flagged_count, verdict (clean|review|ai-sounding), list of flagged entries
-        with headword, occurrences, why_avoid, and alternatives_preview
-    """
-    from src.tools.thesaurus import flag_vocabulary as _flag
-    return _flag(text=text, language=language, domain=domain)
+@mcp.resource("writing-library://rubric-frameworks")
+def resource_rubric_frameworks() -> dict:
+    """Rubric frameworks that have at least one criterion stored, with per-framework criterion counts."""
+    from src.tools.rubrics import list_rubric_frameworks as _list
+    return _list()
 
 
-# ---------------------------------------------------------------------------
-# Contribution moderation (admin-facing)
-#
-# Note: contribute_* tools were removed. Non-admin callers of add_term/
-# add_thesaurus_entry/add_rubric_criterion/add_template are routed to the
-# moderation queue automatically (routed_to="queue"). Admins flow directly
-# into the shared library (routed_to="library"). See those tools' docstrings.
-# ---------------------------------------------------------------------------
-
-@mcp.tool()
-def list_contributions(
-    ctx: Context,
-    status: str = "pending",
-    target: Optional[str] = None,
-    mine: bool = False,
-    limit: int = 50,
-) -> dict:
-    """
-    List contributions from the moderation queue.
-
-    Admins see all contributions. Regular users can only view their own (mine=True is enforced).
-
-    Args:
-        status: Filter by status — pending|published|rejected|all (default: pending)
-        target: Filter by target — terms|thesaurus|rubrics|templates
-        mine: If True, return only your own contributions (always True for non-admins)
-        limit: Max results (default 50)
-
-    Returns:
-        {success, contributions: [...], total}
-    """
-    from src.tools.contributions import list_contributions as _list
-
-    caller = _client_id(ctx)
-    admin_id = os.getenv("ADMIN_CLIENT_ID", "")
-    is_admin = bool(admin_id) and caller == admin_id
-
-    # Non-admins can only see their own contributions
-    contributed_by = caller if (mine or not is_admin) else None
-
-    return _list(status=status, target=target, contributed_by=contributed_by, limit=limit)
+@mcp.resource("writing-library://templates")
+def resource_templates() -> dict:
+    """All stored document templates by framework + doc_type, with section counts."""
+    from src.tools.templates import list_templates as _list
+    return _list()
 
 
-@mcp.tool()
-def review_contribution(
-    contribution_id: str,
-    action: str,
-    ctx: Context,
-    rejection_reason: str = "",
-) -> dict:
-    """
-    **Admin only.** Publish or reject a pending contribution.
-
-    On publish: copies the entry into the target shared collection (terms_shared,
-    thesaurus, rubrics, or templates). On reject: marks as rejected with reason.
-
-    Args:
-        contribution_id: UUID of the contribution to review
-        action: "publish" or "reject"
-        rejection_reason: Required when action="reject"
-
-    Returns:
-        {success, contribution_id, action, target_collection, reviewed_at}
-    """
-    err = _require_admin(ctx)
-    if err:
-        return {"success": False, "error": err}
-
-    from src.tools.contributions import review_contribution as _review
-    return _review(
-        contribution_id=contribution_id,
-        action=action,
-        reviewed_by=_client_id(ctx),
-        rejection_reason=rejection_reason,
-    )
-
-
-# ---------------------------------------------------------------------------
+# ===========================================================================
 # Internal: Telegram notification for new contributions
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 def _notify_contribution(contribution_id: str, target: str, label: str, contributed_by: str) -> None:
     """Fire-and-forget Telegram notification to admin on new contribution."""
@@ -1682,7 +1201,7 @@ def _notify_contribution(contribution_id: str, target: str, label: str, contribu
         f"Entry: `{label}`\n"
         f"From: `{contributed_by}`\n"
         f"ID: `{contribution_id}`\n\n"
-        f"Review with `list_contributions()` → `review_contribution()`"
+        f"Review with `manage_contributions(action='list')` → `manage_contributions(action='review', ...)`"
     )
 
     async def _send():
@@ -1694,8 +1213,8 @@ def _notify_contribution(contribution_id: str, target: str, label: str, contribu
                     json={"chat_id": chat_id, "text": text, "parse_mode": "Markdown"},
                     timeout=5.0,
                 )
-        except Exception as e:
-            logger.warning("Telegram contribution notification failed", error=str(e))
+        except Exception:
+            pass
 
     try:
         loop = asyncio.get_event_loop()

--- a/tests/test_phase1_surface.py
+++ b/tests/test_phase1_surface.py
@@ -1,10 +1,12 @@
-"""Regression tests for Phase 1 tool-surface changes.
+"""Regression tests for the Phase 5A tool surface (20 tools).
 
 Covers:
-    - add_term share/admin branching (personal | library | queue)
-    - add_thesaurus_entry, add_rubric_criterion, add_template admin/non-admin routing
+    - manage_term add share/admin branching (personal | library | queue)
+    - admin_add routing for kind ∈ {thesaurus, rubric, template} (admin | non-admin)
     - score_writing_patterns mode dispatch (ai | semantic-ai | poetry | song | fiction) + invalid
     - check_external_similarity search_results branch
+    - manage_* action dispatch (passage, style_profile, contributions, library)
+    - search_thesaurus rich=True path
 """
 import sys
 import types
@@ -14,7 +16,7 @@ import src.server as server
 
 
 def _install_fake_kbase_indexer(return_value=None):
-    """Inject a fake kbase.vector.sync_indexing module so server.add_term can import it."""
+    """Inject a fake kbase.vector.sync_indexing module so server can import it."""
     idx = MagicMock(return_value=return_value if return_value is not None else ["p1"])
     kbase = sys.modules.setdefault("kbase", types.ModuleType("kbase"))
     vector = sys.modules.setdefault("kbase.vector", types.ModuleType("kbase.vector"))
@@ -33,25 +35,28 @@ def _ok(**extra):
 
 
 # ---------------------------------------------------------------------------
-# add_term — share=False | share=True+admin | share=True+non-admin
+# manage_term(action="add") — share=False | share=True+admin | share=True+non-admin
 # ---------------------------------------------------------------------------
 
-def test_add_term_personal_when_share_false():
+def test_manage_term_add_personal_when_share_false():
     with patch.object(server, "_client_id", return_value="alice"), \
          patch("src.tools.terms.add_term", return_value=_ok()) as personal:
-        result = server.add_term(preferred="rights-holder", ctx=None, share=False)
+        result = server.manage_term(
+            action="add", preferred="rights-holder", ctx=None, share=False,
+        )
     assert result["success"] is True
     assert result["routed_to"] == "personal"
     personal.assert_called_once()
     assert personal.call_args.kwargs["client_id"] == "alice"
 
 
-def test_add_term_library_when_share_true_and_admin():
+def test_manage_term_add_library_when_share_true_and_admin():
     idx = _install_fake_kbase_indexer(return_value=["p1"])
     with patch.object(server, "_client_id", return_value="admin-1"), \
          patch.object(server, "_require_admin", return_value=None):
-        result = server.add_term(
-            preferred="rights-holder", ctx=None, domain="srhr", share=True,
+        result = server.manage_term(
+            action="add", preferred="rights-holder", ctx=None,
+            domain="srhr", share=True,
         )
     assert result["success"] is True
     assert result["routed_to"] == "library"
@@ -59,14 +64,15 @@ def test_add_term_library_when_share_true_and_admin():
     assert idx.call_args.kwargs["metadata"]["contributed_by"] == "admin-1"
 
 
-def test_add_term_queue_when_share_true_and_non_admin():
+def test_manage_term_add_queue_when_share_true_and_non_admin():
     contribute_result = {"success": True, "contribution_id": "c-1"}
     with patch.object(server, "_client_id", return_value="bob"), \
          patch.object(server, "_require_admin", return_value="Admin access required."), \
          patch.object(server, "_notify_contribution"), \
          patch("src.tools.contributions.contribute_term", return_value=contribute_result) as contrib:
-        result = server.add_term(
-            preferred="rights-holder", ctx=None, share=True, note="please review",
+        result = server.manage_term(
+            action="add", preferred="rights-holder", ctx=None,
+            share=True, note="please review",
         )
     assert result["success"] is True
     assert result["routed_to"] == "queue"
@@ -74,88 +80,124 @@ def test_add_term_queue_when_share_true_and_non_admin():
     assert contrib.call_args.kwargs["contributed_by"] == "bob"
 
 
+def test_manage_term_update_requires_document_id():
+    out = server.manage_term(action="update", ctx=None)
+    assert out["success"] is False
+    assert "document_id" in out["error"]
+
+
+def test_manage_term_delete_dispatches():
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch("src.tools.terms.delete_term", return_value={"success": True}) as deleter:
+        result = server.manage_term(action="delete", ctx=None, document_id="t-1")
+    assert result["success"] is True
+    deleter.assert_called_once()
+    assert deleter.call_args.kwargs["document_id"] == "t-1"
+
+
+def test_manage_term_invalid_action():
+    out = server.manage_term(action="bogus", ctx=None)
+    assert out["success"] is False
+    assert "Invalid action" in out["error"]
+
+
 # ---------------------------------------------------------------------------
-# add_thesaurus_entry
+# admin_add(kind="thesaurus")
 # ---------------------------------------------------------------------------
 
-def test_add_thesaurus_entry_admin_routes_library():
+def test_admin_add_thesaurus_admin_routes_library():
     with patch.object(server, "_client_id", return_value="admin-1"), \
          patch.object(server, "_require_admin", return_value=None), \
          patch("src.tools.thesaurus.add_thesaurus_entry", return_value=_ok()) as direct:
-        result = server.add_thesaurus_entry(ctx=None, headword="leverage")
+        result = server.admin_add(kind="thesaurus", ctx=None, headword="leverage")
     assert result["routed_to"] == "library"
     direct.assert_called_once()
 
 
-def test_add_thesaurus_entry_non_admin_routes_queue():
+def test_admin_add_thesaurus_non_admin_routes_queue():
     with patch.object(server, "_client_id", return_value="bob"), \
          patch.object(server, "_require_admin", return_value="no"), \
          patch.object(server, "_notify_contribution"), \
          patch("src.tools.contributions.contribute_thesaurus_entry",
                return_value={"success": True, "contribution_id": "c-2"}) as contrib:
-        result = server.add_thesaurus_entry(ctx=None, headword="leverage", note="ai-ish")
+        result = server.admin_add(kind="thesaurus", ctx=None, headword="leverage", note="ai-ish")
     assert result["routed_to"] == "queue"
     contrib.assert_called_once()
     assert contrib.call_args.kwargs["contributed_by"] == "bob"
 
 
 # ---------------------------------------------------------------------------
-# add_rubric_criterion
+# admin_add(kind="rubric")
 # ---------------------------------------------------------------------------
 
-def test_add_rubric_criterion_admin_routes_library():
+def test_admin_add_rubric_admin_routes_library():
     with patch.object(server, "_client_id", return_value="admin-1"), \
          patch.object(server, "_require_admin", return_value=None), \
          patch("src.tools.rubrics.add_rubric_criterion", return_value=_ok()) as direct:
-        result = server.add_rubric_criterion(
-            ctx=None, framework="usaid", section="technical-approach",
-            criterion="Clear theory of change",
+        result = server.admin_add(
+            kind="rubric", ctx=None, framework="usaid",
+            section="technical-approach", criterion="Clear theory of change",
         )
     assert result["routed_to"] == "library"
     direct.assert_called_once()
 
 
-def test_add_rubric_criterion_non_admin_routes_queue():
+def test_admin_add_rubric_non_admin_routes_queue():
     with patch.object(server, "_client_id", return_value="bob"), \
          patch.object(server, "_require_admin", return_value="no"), \
          patch.object(server, "_notify_contribution"), \
          patch("src.tools.contributions.contribute_rubric",
                return_value={"success": True, "contribution_id": "c-3"}) as contrib:
-        result = server.add_rubric_criterion(
-            ctx=None, framework="usaid", section="sustainability", criterion="x",
+        result = server.admin_add(
+            kind="rubric", ctx=None, framework="usaid",
+            section="sustainability", criterion="x",
         )
     assert result["routed_to"] == "queue"
     contrib.assert_called_once()
 
 
+def test_admin_add_rubric_missing_fields():
+    out = server.admin_add(kind="rubric", ctx=None, framework="usaid")
+    assert out["success"] is False
+    assert "framework" in out["error"] or "section" in out["error"]
+
+
 # ---------------------------------------------------------------------------
-# add_template
+# admin_add(kind="template")
 # ---------------------------------------------------------------------------
 
-def test_add_template_admin_routes_library():
+def test_admin_add_template_admin_routes_library():
     sections = [{"name": "Executive Summary", "description": "summary"}]
     with patch.object(server, "_client_id", return_value="admin-1"), \
          patch.object(server, "_require_admin", return_value=None), \
          patch("src.tools.templates.add_template", return_value=_ok()) as direct:
-        result = server.add_template(
-            ctx=None, framework="undp", doc_type="concept-note", sections=sections,
+        result = server.admin_add(
+            kind="template", ctx=None, framework="undp",
+            doc_type="concept-note", sections=sections,
         )
     assert result["routed_to"] == "library"
     direct.assert_called_once()
 
 
-def test_add_template_non_admin_routes_queue():
+def test_admin_add_template_non_admin_routes_queue():
     sections = [{"name": "Executive Summary", "description": "summary"}]
     with patch.object(server, "_client_id", return_value="bob"), \
          patch.object(server, "_require_admin", return_value="no"), \
          patch.object(server, "_notify_contribution"), \
          patch("src.tools.contributions.contribute_template",
                return_value={"success": True, "contribution_id": "c-4"}) as contrib:
-        result = server.add_template(
-            ctx=None, framework="undp", doc_type="concept-note", sections=sections,
+        result = server.admin_add(
+            kind="template", ctx=None, framework="undp",
+            doc_type="concept-note", sections=sections,
         )
     assert result["routed_to"] == "queue"
     contrib.assert_called_once()
+
+
+def test_admin_add_invalid_kind():
+    out = server.admin_add(kind="bogus", ctx=None)
+    assert out["success"] is False
+    assert "Invalid kind" in out["error"]
 
 
 # ---------------------------------------------------------------------------
@@ -233,3 +275,222 @@ def test_check_external_similarity_fetches_web_when_results_none():
     assert out is sentinel
     fetcher.assert_called_once()
     scorer.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# manage_passage — action dispatch
+# ---------------------------------------------------------------------------
+
+def test_manage_passage_add_single():
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch("src.tools.passages.add_passage", return_value=_ok()) as adder:
+        out = server.manage_passage(action="add", ctx=None, text="x", doc_type="report")
+    assert out["success"] is True
+    adder.assert_called_once()
+    assert adder.call_args.kwargs["client_id"] == "alice"
+
+
+def test_manage_passage_add_batch_uses_items():
+    items = [{"text": "a", "doc_type": "r"}, {"text": "b", "doc_type": "r"}]
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch("src.tools.passages.batch_add_passages", return_value={"success": True, "added": 2}) as batcher:
+        out = server.manage_passage(action="add", ctx=None, items=items)
+    assert out["success"] is True
+    batcher.assert_called_once()
+
+
+def test_manage_passage_update_requires_document_id():
+    out = server.manage_passage(action="update", ctx=None)
+    assert out["success"] is False
+    assert "document_id" in out["error"]
+
+
+def test_manage_passage_correction_action():
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch("src.tools.passages.record_correction", return_value=_ok()) as recorder:
+        out = server.manage_passage(
+            action="correction", ctx=None,
+            original="bad", corrected="good", issue_type="ai-patterns",
+        )
+    assert out["success"] is True
+    recorder.assert_called_once()
+
+
+def test_manage_passage_invalid_action():
+    out = server.manage_passage(action="bogus", ctx=None)
+    assert out["success"] is False
+    assert "Invalid action" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# manage_style_profile — upsert, load, search, list, harvest-corrections
+# ---------------------------------------------------------------------------
+
+def test_manage_style_profile_save_new_profile_creates():
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch("src.tools.style_profiles.load_style_profile",
+               return_value={"success": False}), \
+         patch("src.tools.style_profiles.save_style_profile", return_value=_ok()) as saver, \
+         patch("src.tools.style_profiles.update_style_profile") as updater:
+        out = server.manage_style_profile(
+            action="save", ctx=None, name="danilo",
+            description="desc", style_scores={"narrative": 0.7},
+            rules=["r1"], anti_patterns=["a1"], sample_excerpts=["s1"],
+        )
+    assert out["success"] is True
+    saver.assert_called_once()
+    updater.assert_not_called()
+
+
+def test_manage_style_profile_save_existing_profile_updates():
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch("src.tools.style_profiles.load_style_profile",
+               return_value={"success": True, "profile": {"name": "danilo"}}), \
+         patch("src.tools.style_profiles.save_style_profile") as saver, \
+         patch("src.tools.style_profiles.update_style_profile", return_value=_ok()) as updater:
+        out = server.manage_style_profile(
+            action="save", ctx=None, name="danilo",
+            rules=["new rule"],
+        )
+    assert out["success"] is True
+    updater.assert_called_once()
+    saver.assert_not_called()
+
+
+def test_manage_style_profile_load():
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch("src.tools.style_profiles.load_style_profile",
+               return_value={"success": True}) as loader:
+        out = server.manage_style_profile(action="load", ctx=None, name="danilo")
+    assert out["success"] is True
+    loader.assert_called_once()
+
+
+def test_manage_style_profile_search():
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch("src.tools.style_profiles.search_style_profiles",
+               return_value={"success": True, "matches": []}) as searcher:
+        out = server.manage_style_profile(
+            action="search", ctx=None, text="sample", channel="linkedin",
+        )
+    assert out["success"] is True
+    searcher.assert_called_once()
+
+
+def test_manage_style_profile_list():
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch("src.tools.style_profiles.list_style_profiles",
+               return_value={"success": True, "profiles": []}) as lister:
+        out = server.manage_style_profile(action="list", ctx=None)
+    assert out["success"] is True
+    lister.assert_called_once()
+
+
+def test_manage_style_profile_harvest_corrections():
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch("src.tools.style_profiles.harvest_corrections_to_profile",
+               return_value={"success": True}) as harvester:
+        out = server.manage_style_profile(
+            action="harvest-corrections", ctx=None, name="danilo",
+        )
+    assert out["success"] is True
+    harvester.assert_called_once()
+
+
+def test_manage_style_profile_invalid_action():
+    out = server.manage_style_profile(action="bogus", ctx=None)
+    assert out["success"] is False
+    assert "Invalid action" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# search_thesaurus — rich=False normal, rich=True delegates to suggest_alternatives
+# ---------------------------------------------------------------------------
+
+def test_search_thesaurus_default_path():
+    with patch("src.tools.thesaurus.search_thesaurus",
+               return_value={"success": True, "results": []}) as searcher, \
+         patch("src.tools.thesaurus.suggest_alternatives") as rich:
+        out = server.search_thesaurus(query="leverage")
+    assert out["success"] is True
+    searcher.assert_called_once()
+    rich.assert_not_called()
+
+
+def test_search_thesaurus_rich_uses_suggest_alternatives():
+    with patch("src.tools.thesaurus.search_thesaurus") as searcher, \
+         patch("src.tools.thesaurus.suggest_alternatives",
+               return_value={"success": True, "alternatives": []}) as rich:
+        out = server.search_thesaurus(query="leverage", rich=True)
+    assert out["success"] is True
+    rich.assert_called_once()
+    searcher.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# manage_contributions — list, review (review requires admin)
+# ---------------------------------------------------------------------------
+
+def test_manage_contributions_list():
+    with patch("src.tools.contributions.list_contributions",
+               return_value={"success": True, "contributions": []}) as lister:
+        out = server.manage_contributions(action="list", ctx=None)
+    assert out["success"] is True
+    lister.assert_called_once()
+
+
+def test_manage_contributions_review_requires_admin():
+    with patch.object(server, "_require_admin", return_value="Admin required."):
+        out = server.manage_contributions(
+            action="review", ctx=None, contribution_id="c-1", review_action="publish",
+        )
+    assert out["success"] is False
+    assert "Admin" in out["error"] or "admin" in out["error"]
+
+
+def test_manage_contributions_review_admin_dispatches():
+    with patch.object(server, "_client_id", return_value="admin-1"), \
+         patch.object(server, "_require_admin", return_value=None), \
+         patch("src.tools.contributions.review_contribution",
+               return_value={"success": True}) as reviewer:
+        out = server.manage_contributions(
+            action="review", ctx=None, contribution_id="c-1", review_action="publish",
+        )
+    assert out["success"] is True
+    reviewer.assert_called_once()
+
+
+def test_manage_contributions_invalid_action():
+    out = server.manage_contributions(action="bogus", ctx=None)
+    assert out["success"] is False
+    assert "Invalid action" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# manage_library — stats, export
+# ---------------------------------------------------------------------------
+
+def test_manage_library_stats():
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch("src.tools.collections.get_stats",
+               return_value={"success": True, "stats": {}}) as stats:
+        out = server.manage_library(action="stats", ctx=None)
+    assert out["success"] is True
+    stats.assert_called_once()
+
+
+def test_manage_library_export():
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch("src.tools.export.export_library",
+               return_value={"success": True, "format": "json"}) as exporter:
+        out = server.manage_library(
+            action="export", ctx=None, collection="passages", output_format="json",
+        )
+    assert out["success"] is True
+    exporter.assert_called_once()
+
+
+def test_manage_library_invalid_action():
+    out = server.manage_library(action="bogus", ctx=None)
+    assert out["success"] is False
+    assert "Invalid action" in out["error"]


### PR DESCRIPTION
## Summary
- Consolidates 40 MCP tools into 20 via `manage_*(action, ...)` and `admin_add(kind, ...)` dispatch
- Demotes `list_styles` / `list_rubric_frameworks` / `list_templates` to MCP resources
- Removes `setup_collections` from public surface (retained as lazy internal helper)

## Test plan
- [x] `tests/test_phase1_surface.py` rewritten with dispatch coverage — 43/43 passing
- [x] Full suite: 289 passing, 28 pre-existing failures (kbase imports, stale styles count) — unrelated to this refactor
- [ ] Manual smoke via MCP client after merge

See `docs/phase-5a-tool-surface-proposal.md` for the full mapping.