### PR TITLE
fix: Unknown pattern file: para_limits (sentry MCP-WRITING-A)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN uv pip install --system -e . --no-cache-dir
 # Copy application source and vendored libraries
 COPY src/ ./src/
 COPY vendor/ ./vendor/
+COPY data/ ./data/
 COPY main.py ./
 
 # Default to HTTP transport for Railway


### PR DESCRIPTION
## Root cause

`score_writing_patterns` fails immediately at its first line — `para_limits_map = _para_limits(client_id)` — which calls `load_values("para_limits")`, which reads from `data/patterns/para_limits.json`. That file exists in the repo (added 2026‑04‑22 in [43b735f0](https://github.com/dsmoz/mcp-writing-library/commit/43b735f0f24e343d108ea300d816477ebfbf0515)) but is **never copied into the Docker image** — the Dockerfile only copies `src/`, `vendor/`, and `main.py`. Every pattern‑store read therefore `_read_json()` returns `None` and `load_values` raises `FileNotFoundError("Unknown pattern file: para_limits")`.

The Sentry issue's first occurrence (2026‑04‑22 16:46) matches the deploy of that commit.

## What changed

Added `COPY data/ ./data/` to the Dockerfile so `CORE_DIR = /app/data/patterns` resolves at runtime.

## Files touched

- `Dockerfile` (+1 line)

## Sentry

- Issue: [MCP-WRITING-A](https://dsmoz.sentry.io/issues/MCP-WRITING-A) — `ToolError: Error executing tool score_writing_patterns: Unknown pattern file: para_limits`
- 5 events, first seen 2026‑04‑22, last seen 2026‑04‑23
- Once merged & redeployed, all pattern-based detectors in `score_ai_patterns`, `score_pt_forensic`, `score_poetry_patterns`, `score_song_patterns`, and `score_fiction_patterns` should work as designed.

## Test plan

- [ ] Redeploy to Railway
- [ ] Call `score_writing_patterns(mode="ai", text="...", doc_type="general")` and confirm it returns a scored response (not a tool error)
- [ ] Check that `data/patterns/para_limits.json` exists at `/app/data/patterns/para_limits.json` inside the image

---

🤖 Opened by the DS-MOZ Sentry triage routine · no auto-merge (deploy-config change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VZcGYvrcSYMvWpNtEeHzsx)_