### PR TITLE
fix: Qdrant 400 missing document_id index on style_profiles (sentry MCP-WRITING-9)

### DIFF
--- a/scripts/fix_style_profiles_indexes.py
+++ b/scripts/fix_style_profiles_indexes.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """
-One-off fix: create missing 'name' and 'channel' payload indexes
-on existing style_profiles collections.
+One-off fix: create missing payload indexes on existing style_profiles collections.
+
+Indexes are required for any payload field used in a Qdrant filter. Missing
+indexes surface as HTTP 400 "Index required but not found for <field>" when
+update_style_profile / load_style_profile / list_style_profiles filter by
+the field.
 
     uv run python scripts/fix_style_profiles_indexes.py
 """
@@ -41,7 +45,7 @@ def main():
 
     for coll in targets:
         print(f"\nFixing indexes on: {coll}")
-        for field in ("name", "channel", "client_id"):
+        for field in ("name", "channel", "client_id", "document_id"):
             try:
                 client.create_payload_index(
                     collection_name=coll,


### PR DESCRIPTION
## Root cause

`update_style_profile` (src/tools/style_profiles.py:333) calls the vendored `delete_document_vectors`, which scrolls the style_profiles collection with a filter on `document_id`. Qdrant rejects the scroll with HTTP 400:

```
Bad request: Index required but not found for "document_id" of one of the following types: [keyword, uuid].
```

Existing per-user style_profiles collections have payload indexes on `name`, `channel`, and `client_id` (created by `scripts/fix_style_profiles_indexes.py`), but **not on `document_id`**.

## What changed

Added `"document_id"` to the field tuple in `scripts/fix_style_profiles_indexes.py`. The field list is now `("name", "channel", "client_id", "document_id")`.

## Files touched

- `scripts/fix_style_profiles_indexes.py` (+1 field in tuple, docstring refreshed)

## Operational follow-up

After this PR merges, the script must be re-run against the production Qdrant instance to create the missing index on existing collections:

```
uv run python scripts/fix_style_profiles_indexes.py
```

The script is idempotent — existing `name`/`channel`/`client_id` indexes will be skipped.

## Sentry

- Issue: [MCP-WRITING-9](https://dsmoz.sentry.io/issues/MCP-WRITING-9) — `UnexpectedResponse: 400 Bad Request — Index required but not found for "document_id"`
- 2 events, first seen 2026‑04‑19, last seen 2026‑04‑23
- Related: [MCP-WRITING-A](https://dsmoz.sentry.io/issues/MCP-WRITING-A) (separate PR #6)

## Test plan

- [ ] Merge PR
- [ ] Run `uv run python scripts/fix_style_profiles_indexes.py` against Railway Qdrant
- [ ] Call `update_style_profile(name="danilo-voice-pt", new_rules=["test"])` and confirm old vectors are cleaned up (no 400, no duplicate profile versions on subsequent load)

---

🤖 Opened by the DS-MOZ Sentry triage routine · no auto-merge (schema/migration script)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VZcGYvrcSYMvWpNtEeHzsx)_