### PR TITLE
fix(consistency): propagate client_id through score_voice_consistency

### DIFF
--- a/.project-structure.md
+++ b/.project-structure.md
@@ -1,10 +1,10 @@
 # Project Structure
 
-**Generated**: 2026-04-22 15:18:51
+**Generated**: 2026-04-24 03:11:15
 
 ## Directory Structure
 
-blissful-black-4d5208/
+loving-lichterman-173a40/
 ├── [.dockerignore](.dockerignore)
 ├── [.env.example](.env.example)
 ├── [.git](.git)
@@ -36,9 +36,7 @@ blissful-black-4d5208/
 │       ├── [para_limits.json](data/patterns/para_limits.json)
 │       ├── [passive_patterns.json](data/patterns/passive_patterns.json)
 │       ├── [pt_function_words.json](data/patterns/pt_function_words.json)
-│       ├── [pt_passive_patterns.json](data/patterns/pt_passive_patterns.json)
-│       └── users/
-│           └── alice/
+│       └── [pt_passive_patterns.json](data/patterns/pt_passive_patterns.json)
 ├── docs/
 │   ├── [phase-5a-tool-surface-proposal.md](docs/phase-5a-tool-surface-proposal.md)
 │   └── superpowers/
@@ -68,47 +66,13 @@ blissful-black-4d5208/
 │   └── [setup_collections.py](scripts/setup_collections.py)
 ├── src/
 │   ├── [__init__.py](src/__init__.py)
-│   ├── __pycache__/
-│   │   ├── [__init__.cpython-312.pyc](src/__pycache__/__init__.cpython-312.pyc)
-│   │   ├── [__init__.cpython-314.pyc](src/__pycache__/__init__.cpython-314.pyc)
-│   │   ├── [sentry.cpython-312.pyc](src/__pycache__/sentry.cpython-312.pyc)
-│   │   └── [server.cpython-312.pyc](src/__pycache__/server.cpython-312.pyc)
 │   ├── models/
 │   │   ├── [__init__.py](src/models/__init__.py)
-│   │   ├── __pycache__/
-│   │   │   ├── [__init__.cpython-312.pyc](src/models/__pycache__/__init__.cpython-312.pyc)
-│   │   │   └── [responses.cpython-312.pyc](src/models/__pycache__/responses.cpython-312.pyc)
 │   │   └── [responses.py](src/models/responses.py)
 │   ├── [sentry.py](src/sentry.py)
 │   ├── [server.py](src/server.py)
 │   └── tools/
 │       ├── [__init__.py](src/tools/__init__.py)
-│       ├── __pycache__/
-│       │   ├── [__init__.cpython-312.pyc](src/tools/__pycache__/__init__.cpython-312.pyc)
-│       │   ├── [__init__.cpython-314.pyc](src/tools/__pycache__/__init__.cpython-314.pyc)
-│       │   ├── [ai_patterns.cpython-312.pyc](src/tools/__pycache__/ai_patterns.cpython-312.pyc)
-│       │   ├── [ai_patterns.cpython-314.pyc](src/tools/__pycache__/ai_patterns.cpython-314.pyc)
-│       │   ├── [collections.cpython-312.pyc](src/tools/__pycache__/collections.cpython-312.pyc)
-│       │   ├── [consistency.cpython-312.pyc](src/tools/__pycache__/consistency.cpython-312.pyc)
-│       │   ├── [contributions.cpython-312.pyc](src/tools/__pycache__/contributions.cpython-312.pyc)
-│       │   ├── [evidence.cpython-312.pyc](src/tools/__pycache__/evidence.cpython-312.pyc)
-│       │   ├── [export.cpython-312.pyc](src/tools/__pycache__/export.cpython-312.pyc)
-│       │   ├── [fiction_patterns.cpython-312.pyc](src/tools/__pycache__/fiction_patterns.cpython-312.pyc)
-│       │   ├── [passages.cpython-312.pyc](src/tools/__pycache__/passages.cpython-312.pyc)
-│       │   ├── [pattern_store.cpython-312.pyc](src/tools/__pycache__/pattern_store.cpython-312.pyc)
-│       │   ├── [pattern_store.cpython-314.pyc](src/tools/__pycache__/pattern_store.cpython-314.pyc)
-│       │   ├── [plagiarism.cpython-312.pyc](src/tools/__pycache__/plagiarism.cpython-312.pyc)
-│       │   ├── [poetry_patterns.cpython-312.pyc](src/tools/__pycache__/poetry_patterns.cpython-312.pyc)
-│       │   ├── [pt_forensic.cpython-312.pyc](src/tools/__pycache__/pt_forensic.cpython-312.pyc)
-│       │   ├── [qdrant_errors.cpython-312.pyc](src/tools/__pycache__/qdrant_errors.cpython-312.pyc)
-│       │   ├── [registry.cpython-312.pyc](src/tools/__pycache__/registry.cpython-312.pyc)
-│       │   ├── [rubrics.cpython-312.pyc](src/tools/__pycache__/rubrics.cpython-312.pyc)
-│       │   ├── [song_patterns.cpython-312.pyc](src/tools/__pycache__/song_patterns.cpython-312.pyc)
-│       │   ├── [style_profiles.cpython-312.pyc](src/tools/__pycache__/style_profiles.cpython-312.pyc)
-│       │   ├── [styles.cpython-312.pyc](src/tools/__pycache__/styles.cpython-312.pyc)
-│       │   ├── [templates.cpython-312.pyc](src/tools/__pycache__/templates.cpython-312.pyc)
-│       │   ├── [terms.cpython-312.pyc](src/tools/__pycache__/terms.cpython-312.pyc)
-│       │   └── [thesaurus.cpython-312.pyc](src/tools/__pycache__/thesaurus.cpython-312.pyc)
 │       ├── [ai_patterns.py](src/tools/ai_patterns.py)
 │       ├── [collections.py](src/tools/collections.py)
 │       ├── [consistency.py](src/tools/consistency.py)
@@ -132,30 +96,6 @@ blissful-black-4d5208/
 │       └── [thesaurus.py](src/tools/thesaurus.py)
 ├── tests/
 │   ├── [__init__.py](tests/__init__.py)
-│   ├── __pycache__/
-│   │   ├── [__init__.cpython-312.pyc](tests/__pycache__/__init__.cpython-312.pyc)
-│   │   ├── [__init__.cpython-314.pyc](tests/__pycache__/__init__.cpython-314.pyc)
-│   │   ├── [conftest.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/conftest.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [conftest.cpython-314-pytest-9.0.2.pyc](tests/__pycache__/conftest.cpython-314-pytest-9.0.2.pyc)
-│   │   ├── [test_ai_patterns.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_ai_patterns.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_ai_patterns.cpython-314-pytest-9.0.2.pyc](tests/__pycache__/test_ai_patterns.cpython-314-pytest-9.0.2.pyc)
-│   │   ├── [test_collections.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_collections.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_consistency.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_consistency.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_evidence.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_evidence.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_export.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_export.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_passages.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_passages.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_pattern_store.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_pattern_store.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_phase1_surface.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_phase1_surface.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_plagiarism.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_plagiarism.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_pt_forensic.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_pt_forensic.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_qdrant_errors.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_qdrant_errors.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_rubrics.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_rubrics.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_style_profiles.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_style_profiles.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_styles.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_styles.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_templates.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_templates.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_terms.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_terms.cpython-312-pytest-9.0.2.pyc)
-│   │   ├── [test_thesaurus.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_thesaurus.cpython-312-pytest-9.0.2.pyc)
-│   │   └── [test_transport.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_transport.cpython-312-pytest-9.0.2.pyc)
 │   ├── [conftest.py](tests/conftest.py)
 │   ├── [test_ai_patterns.py](tests/test_ai_patterns.py)
 │   ├── [test_collections.py](tests/test_collections.py)

--- a/src/server.py
+++ b/src/server.py
@@ -458,6 +458,7 @@ def check_structure(text: str, framework: str, doc_type: str) -> StructureCheckR
 @mcp.tool()
 def score_voice_consistency(
     sections: List[str],
+    ctx: Context,
     profile_name: Optional[str] = None,
     top_k_profile: int = 1,
 ) -> dict:
@@ -476,7 +477,12 @@ def score_voice_consistency(
         per-section drift_score / profile_score, highest_drift_section.
     """
     from src.tools.consistency import score_voice_consistency as _score
-    return _score(sections=sections, profile_name=profile_name, top_k_profile=top_k_profile)
+    return _score(
+        sections=sections,
+        profile_name=profile_name,
+        top_k_profile=top_k_profile,
+        client_id=_client_id(ctx),
+    )
 
 
 @mcp.tool()

--- a/src/server.py
+++ b/src/server.py
@@ -9,7 +9,7 @@ Scoring / search (12, unchanged):
 Merged CRUD / manage (7):
     manage_passage(action ∈ {add, update, delete, correction})
     manage_term(action ∈ {add, update, delete})  — share-branching preserved
-    manage_style_profile(action ∈ {save, load, search, list, harvest-corrections, inject-context})
+    manage_style_profile(action ∈ {save, load, search, list, delete, harvest-corrections, inject-context})
     search_thesaurus(query, rich=False, ...)  — rich=True = former suggest_alternatives
     manage_contributions(action ∈ {list, review})
     manage_library(action ∈ {stats, export})
@@ -164,7 +164,7 @@ def _build_mcp() -> FastMCP:
         "  1. Vocabulary review: search_terms → apply preferred term with `why` as rationale.\n"
         "  2. Seed model passages: check_internal_similarity → manage_passage(action='add').\n"
         "  3. Corrections pair: manage_passage(action='correction', original=..., corrected=...).\n"
-        "  4. Style profiles: manage_style_profile(action ∈ {save, load, search, list, harvest-corrections}).\n"
+        "  4. Style profiles: manage_style_profile(action ∈ {save, load, search, list, delete, harvest-corrections}).\n"
         "  5. Craft scoring: score_writing_patterns(mode ∈ {ai|pt|semantic-ai|poetry|song|fiction}).\n"
         "  6. Evidence: verify_claims (ghost_stat=True always blocks) + score_evidence_density.\n"
         "  7. Rubric alignment: score_against_rubric; admins add criteria via admin_add(kind='rubric').\n"
@@ -781,6 +781,8 @@ def manage_style_profile(
     language: Optional[str] = None,
     domain: Optional[str] = None,
     min_corrections: int = 3,
+    # delete
+    document_id: Optional[str] = None,
 ) -> dict:
     """
     Manage writing style profiles (per-user, channel-tagged).
@@ -793,6 +795,9 @@ def manage_style_profile(
         load                 — Load by exact `name`.
         search               — Find profiles similar to `text`. Optional `channel` filter.
         list                 — List all profiles. Optional `channel` filter, `limit`.
+        delete               — Remove all chunks for a profile by `document_id` from the
+                               caller's per-user collection. Cross-user deletion is
+                               blocked by collection-prefix isolation.
         harvest-corrections  — Scan correction corpus and surface candidate rules to merge
                                into profile `name`. Returns candidates only — agent must
                                re-save with manage_style_profile(action='save') after review.
@@ -801,7 +806,7 @@ def manage_style_profile(
                                prompt. Research shows 3–5 excerpts give up to 23.5× style fidelity.
 
     Args:
-        action: save|load|search|list|harvest-corrections|inject-context
+        action: save|load|search|list|delete|harvest-corrections|inject-context
         name: Profile name (required by save/load/harvest-corrections)
         channel: Publishing surface (linkedin|email|report|proposal|general|...)
         style_scores, rules, anti_patterns, sample_excerpts, description, source_documents:
@@ -811,9 +816,10 @@ def manage_style_profile(
         top_k: search — results count (default 3)
         limit: list — max profiles (default 50)
         language, domain, min_corrections: harvest-corrections filters
+        document_id: delete — profile document UUID to remove (required)
 
     Returns:
-        Action-specific dict.
+        Action-specific dict. delete returns {success, document_id, chunks_deleted}.
     """
     client_id = _client_id(ctx)
 
@@ -890,7 +896,13 @@ def manage_style_profile(
         from src.tools.style_profiles import get_style_injection_context as _inject
         return _inject(name=name, client_id=client_id)
 
-    return {"success": False, "error": f"Invalid action '{action}'. Must be one of: save, load, search, list, harvest-corrections, inject-context"}
+    if action == "delete":
+        if not document_id:
+            return {"success": False, "error": "action='delete' requires 'document_id'"}
+        from src.tools.style_profiles import delete_style_profile as _delete
+        return _delete(document_id=document_id, client_id=client_id)
+
+    return {"success": False, "error": f"Invalid action '{action}'. Must be one of: save, load, search, list, delete, harvest-corrections, inject-context"}
 
 
 @mcp.tool()

--- a/src/tools/consistency.py
+++ b/src/tools/consistency.py
@@ -54,6 +54,7 @@ def score_voice_consistency(
     sections: List[str],
     profile_name: Optional[str] = None,
     top_k_profile: int = 1,
+    client_id: str = "default",
 ) -> dict:
     """
     Measure how consistently a list of text sections share a voice/style.
@@ -115,7 +116,7 @@ def score_voice_consistency(
         # Step 4: Profile comparison
         if profile_name is not None:
             from src.tools.style_profiles import load_style_profile
-            profile_result = load_style_profile(name=profile_name)
+            profile_result = load_style_profile(name=profile_name, client_id=client_id)
             if not profile_result.get("success"):
                 return {
                     "success": False,
@@ -150,7 +151,7 @@ def score_voice_consistency(
         # Profile comparison skipped in fallback mode
         if profile_name is not None:
             from src.tools.style_profiles import load_style_profile
-            profile_result = load_style_profile(name=profile_name)
+            profile_result = load_style_profile(name=profile_name, client_id=client_id)
             if not profile_result.get("success"):
                 return {
                     "success": False,

--- a/src/tools/style_profiles.py
+++ b/src/tools/style_profiles.py
@@ -23,7 +23,7 @@ def _style_profiles_collection(client_id: str = "default") -> str:
     return get_user_collection_names(client_id)["style_profiles"]
 
 try:
-    from kbase.vector.sync_indexing import index_document, delete_document_vectors
+    from kbase.vector.sync_indexing import index_document, delete_document_vectors, check_document_indexed
     from kbase.vector.sync_search import semantic_search
     from qdrant_client import QdrantClient
     from qdrant_client.http.models import Filter, FieldCondition, MatchValue
@@ -32,6 +32,7 @@ try:
 except ImportError:
     index_document = None  # type: ignore
     delete_document_vectors = None  # type: ignore
+    check_document_indexed = None  # type: ignore
     semantic_search = None  # type: ignore
     _qdrant_available = False
 
@@ -204,6 +205,39 @@ def load_style_profile(name: str, client_id: str = "default") -> dict:
             return qdrant_result
         logger.error("Failed to load style profile", name=name, error=str(e))
         capture_tool_error(e, tool_name="load_style_profile", name=name)
+        return {"success": False, "error": str(e)}
+
+
+def delete_style_profile(document_id: str, client_id: str = "default") -> dict:
+    """Delete all chunks for a style profile by document_id from the user's collection.
+
+    Cross-user deletion is prevented by collection-prefix isolation: the collection
+    resolves to `{client_id}_writing_style_profiles`, so callers can only delete
+    documents that live under their own tenant.
+    """
+    collection = _style_profiles_collection(client_id)
+    try:
+        if check_document_indexed is None or delete_document_vectors is None:
+            return {"success": False, "error": "kbase indexing unavailable"}
+
+        check_result = check_document_indexed(
+            collection_name=collection,
+            document_id=document_id,
+        )
+        chunks = check_result.get("chunk_count", 0)
+        if chunks == 0:
+            return {"success": True, "document_id": document_id, "chunks_deleted": 0}
+
+        delete_document_vectors(collection_name=collection, document_id=document_id)
+        return {"success": True, "document_id": document_id, "chunks_deleted": chunks}
+    except Exception as e:
+        qdrant_result = handle_qdrant_error(
+            e, tool_name="delete_style_profile", collection=collection, document_id=document_id
+        )
+        if qdrant_result is not None:
+            return qdrant_result
+        logger.error("Failed to delete style profile", error=str(e), document_id=document_id)
+        capture_tool_error(e, tool_name="delete_style_profile", document_id=document_id)
         return {"success": False, "error": str(e)}
 
 


### PR DESCRIPTION
Fixes #10

## Change

- `src/server.py`: add `ctx: Context` to `score_voice_consistency` wrapper, thread `client_id=_client_id(ctx)` into the inner scorer.
- `src/tools/consistency.py`: accept `client_id: str = "default"` in `score_voice_consistency`, forward to both `load_style_profile` call sites (embedding + Jaccard fallback branches).

## Not affected

`detect_authorship_shift` does not use style profiles — no change needed.

## Verification

- `python3 -m ast` parse check: OK
- Existing `load_style_profile` already filters by exact `name` via Qdrant `scroll` + `FieldCondition` — no change needed there.