### PR TITLE
fix(apps): use text/html+mcp MIME for Claude.ai

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1395,7 +1395,7 @@ def list_review_sessions(
     return _list(client_id=_client_id(ctx), status=status)
 
 
-@mcp.resource("ui://review-session/panel", mime_type="text/html+skybridge")
+@mcp.resource("ui://review-session/panel", mime_type="text/html+mcp")
 def resource_review_session() -> str:
     """Static HTML review panel — rendered as iframe by MCP Apps hosts.
 


### PR DESCRIPTION
## Summary
- Claude.ai rejects `text/html+skybridge` (OpenAI ChatGPT Apps SDK) with `Unsupported UI resource content format`
- Anthropic canonical MCP Apps spec requires `text/html+mcp`
- One-line fix at `src/server.py:1398`

## Test plan
- [ ] Railway redeploy
- [ ] `mcp-writing-library__start_review_session` renders UI card in Claude.ai