### PR TITLE
fix(apps): rotate MIME to text/html+skybridge + debug sentinel

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"6fe9ad80-e270-40ed-8111-8e33dc39d1cd","pid":16776,"acquiredAt":1777058337336}

--- a/.project-structure.md
+++ b/.project-structure.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-**Generated**: 2026-04-24 05:09:01
+**Generated**: 2026-04-24 18:50:00
 
 ## Directory Structure
 

--- a/.project-structure.md
+++ b/.project-structure.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-**Generated**: 2026-04-24 18:50:00
+**Generated**: 2026-04-24 19:28:24
 
 ## Directory Structure
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ COPY pyproject.toml uv.lock README.md ./
 # Install all dependencies (kbase-core is vendored — no git fetch needed)
 RUN uv pip install --system -e . --no-cache-dir
 
+# Cache bust for source layer
+ARG CACHE_BUST=unset
+RUN echo "CACHE_BUST=${CACHE_BUST}"
+
 # Copy application source and vendored libraries
 COPY src/ ./src/
 COPY vendor/ ./vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ COPY pyproject.toml uv.lock README.md ./
 # Install all dependencies (kbase-core is vendored — no git fetch needed)
 RUN uv pip install --system -e . --no-cache-dir
 
-# Cache bust for source layer
-ARG CACHE_BUST=unset
-RUN echo "CACHE_BUST=${CACHE_BUST}"
+# Cache bust for source layer — change this value to force fresh src copy
+ENV BUILD_TAG=2026-04-24-sentinel-v3
+RUN echo "BUILD_TAG=$BUILD_TAG"
 
 # Copy application source and vendored libraries
 COPY src/ ./src/

--- a/src/server.py
+++ b/src/server.py
@@ -1395,7 +1395,7 @@ def list_review_sessions(
     return _list(client_id=_client_id(ctx), status=status)
 
 
-@mcp.resource("ui://review-session/panel", mime_type="text/html+skybridge")
+@mcp.resource("ui://review-session/panel", mime_type="text/html+mcp")
 def resource_review_session() -> str:
     """Static HTML review panel — rendered as iframe by MCP Apps hosts.
 

--- a/src/server.py
+++ b/src/server.py
@@ -186,6 +186,7 @@ def _build_mcp() -> FastMCP:
     return FastMCP("writing-library", instructions=instructions)
 
 mcp = _build_mcp()
+print("BUILD_SENTINEL=review-tools-v2 mcp-writing-library src/server.py loaded", file=sys.stderr)
 
 
 # ===========================================================================

--- a/src/server.py
+++ b/src/server.py
@@ -1395,7 +1395,7 @@ def list_review_sessions(
     return _list(client_id=_client_id(ctx), status=status)
 
 
-@mcp.resource("ui://review-session/panel", mime_type="text/html+mcp")
+@mcp.resource("ui://review-session/panel", mime_type="text/html+skybridge")
 def resource_review_session() -> str:
     """Static HTML review panel — rendered as iframe by MCP Apps hosts.
 


### PR DESCRIPTION
## Summary

- Rotate `ui://review-session/panel` MIME from `text/html+mcp` → `text/html+skybridge` per advisor directive (OpenAI-origin MIME empirically accepted by Claude.ai + ChatGPT MCP Apps)
- Add `BUILD_SENTINEL` startup log to verify image freshness
- Dockerfile `BUILD_TAG` env for cache-bust

## Test plan

- [ ] Railway auto-deploys on merge
- [ ] `railway logs | grep BUILD_SENTINEL` confirms image fresh
- [ ] `tools/list` contains `start_review_session` with `_meta.ui.resourceUri`
- [ ] `resources/read ui://review-session/panel` returns `mimeType: text/html+skybridge`
- [ ] Claude.ai renders review panel inline