### PR TITLE
fix(apps): attach _meta+structuredContent to start_review_session result

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"6fe9ad80-e270-40ed-8111-8e33dc39d1cd","pid":16776,"acquiredAt":1777058337336}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"6fe9ad80-e270-40ed-8111-8e33dc39d1cd","pid":16776,"acquiredAt":1777058337336}

--- a/.project-structure.md
+++ b/.project-structure.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-**Generated**: 2026-04-24 19:28:24
+**Generated**: 2026-04-24 19:39:55
 
 ## Directory Structure
 

--- a/.project-structure.md
+++ b/.project-structure.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-**Generated**: 2026-04-24 05:09:01
+**Generated**: 2026-04-24 18:50:00
 
 ## Directory Structure
 

--- a/.project-structure.md
+++ b/.project-structure.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-**Generated**: 2026-04-24 19:28:24
+**Generated**: 2026-04-24 19:29:57
 
 ## Directory Structure
 

--- a/.project-structure.md
+++ b/.project-structure.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-**Generated**: 2026-04-24 18:50:00
+**Generated**: 2026-04-24 19:28:24
 
 ## Directory Structure
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ COPY pyproject.toml uv.lock README.md ./
 # Install all dependencies (kbase-core is vendored — no git fetch needed)
 RUN uv pip install --system -e . --no-cache-dir
 
+# Cache bust for source layer
+ARG CACHE_BUST=unset
+RUN echo "CACHE_BUST=${CACHE_BUST}"
+
 # Copy application source and vendored libraries
 COPY src/ ./src/
 COPY vendor/ ./vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ COPY pyproject.toml uv.lock README.md ./
 # Install all dependencies (kbase-core is vendored — no git fetch needed)
 RUN uv pip install --system -e . --no-cache-dir
 
-# Cache bust for source layer
-ARG CACHE_BUST=unset
-RUN echo "CACHE_BUST=${CACHE_BUST}"
+# Cache bust for source layer — change this value to force fresh src copy
+ENV BUILD_TAG=2026-04-24-sentinel-v3
+RUN echo "BUILD_TAG=$BUILD_TAG"
 
 # Copy application source and vendored libraries
 COPY src/ ./src/

--- a/src/server.py
+++ b/src/server.py
@@ -1395,7 +1395,7 @@ def list_review_sessions(
     return _list(client_id=_client_id(ctx), status=status)
 
 
-@mcp.resource("ui://review-session/panel", mime_type="text/html+skybridge")
+@mcp.resource("ui://review-session/panel", mime_type="text/html+mcp")
 def resource_review_session() -> str:
     """Static HTML review panel — rendered as iframe by MCP Apps hosts.
 

--- a/src/server.py
+++ b/src/server.py
@@ -186,6 +186,7 @@ def _build_mcp() -> FastMCP:
     return FastMCP("writing-library", instructions=instructions)
 
 mcp = _build_mcp()
+print("BUILD_SENTINEL=review-tools-v2 mcp-writing-library src/server.py loaded", file=sys.stderr)
 
 
 # ===========================================================================

--- a/src/server.py
+++ b/src/server.py
@@ -1395,7 +1395,7 @@ def list_review_sessions(
     return _list(client_id=_client_id(ctx), status=status)
 
 
-@mcp.resource("ui://review-session/panel", mime_type="text/html+mcp")
+@mcp.resource("ui://review-session/panel", mime_type="text/html+skybridge")
 def resource_review_session() -> str:
     """Static HTML review panel — rendered as iframe by MCP Apps hosts.
 

--- a/src/server.py
+++ b/src/server.py
@@ -26,11 +26,13 @@ Resources (3, demoted from list_* tools):
 
 Setup is internal: setup_collections is called lazily on first write; no longer a public tool.
 """
+import json
 import os
 import sys
 import requests
 from contextvars import ContextVar
 from typing import Optional, List
+from mcp import types
 from mcp.server.fastmcp import FastMCP, Context
 
 from src.models import (
@@ -1319,7 +1321,7 @@ def start_review_session(
     items: List[dict],
     ctx: Context,
     name: Optional[str] = None,
-) -> dict:
+) -> types.CallToolResult:
     """
     Create an interactive review session and return a ui:// resource for in-chat rendering.
 
@@ -1342,7 +1344,13 @@ def start_review_session(
         The UI template is advertised on the tool descriptor via _meta.ui.resourceUri.
     """
     from src.tools.review import start_review_session as _start
-    return _start(items=items, client_id=_client_id(ctx), name=name)
+    result = _start(items=items, client_id=_client_id(ctx), name=name)
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=json.dumps(result, indent=2))],
+        structuredContent=result,
+        _meta={"ui": {"resourceUri": "ui://review-session/panel"}},
+        isError=False,
+    )
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary
- FastMCP 1.x `@mcp.tool(meta=...)` only propagates to tools/list, not CallToolResult
- Plain `dict` return skips structuredContent
- Claude.ai iframe render needs `_meta.ui.resourceUri` on tool-call result + structuredContent for postMessage
- Fix: return explicit `types.CallToolResult` with both fields

## Test plan
- [ ] Railway redeploys on merge
- [ ] Direct tools/call probe confirms _meta + structuredContent present
- [ ] Claude.ai renders review panel iframe end-to-end
