### PR TITLE
feat(admin): role-based admin via OAuth introspect, replace env-var allowlist

### DIFF
--- a/.project-structure.md
+++ b/.project-structure.md
@@ -1,10 +1,10 @@
 # Project Structure
 
-**Generated**: 2026-04-29 03:59:24
+**Generated**: 2026-05-15 12:15:45
 
 ## Directory Structure
 
-tender-raman-22cce2/
+competent-euler-f51178/
 ├── [.dockerignore](.dockerignore)
 ├── [.env.example](.env.example)
 ├── [.git](.git)
@@ -66,8 +66,17 @@ tender-raman-22cce2/
 │   └── [setup_collections.py](scripts/setup_collections.py)
 ├── src/
 │   ├── [__init__.py](src/__init__.py)
+│   ├── __pycache__/
+│   │   ├── [__init__.cpython-312.pyc](src/__pycache__/__init__.cpython-312.pyc)
+│   │   ├── [__init__.cpython-314.pyc](src/__pycache__/__init__.cpython-314.pyc)
+│   │   ├── [sentry.cpython-312.pyc](src/__pycache__/sentry.cpython-312.pyc)
+│   │   ├── [server.cpython-312.pyc](src/__pycache__/server.cpython-312.pyc)
+│   │   └── [server.cpython-314.pyc](src/__pycache__/server.cpython-314.pyc)
 │   ├── models/
 │   │   ├── [__init__.py](src/models/__init__.py)
+│   │   ├── __pycache__/
+│   │   │   ├── [__init__.cpython-312.pyc](src/models/__pycache__/__init__.cpython-312.pyc)
+│   │   │   └── [responses.cpython-312.pyc](src/models/__pycache__/responses.cpython-312.pyc)
 │   │   └── [responses.py](src/models/responses.py)
 │   ├── [sentry.py](src/sentry.py)
 │   ├── [server.py](src/server.py)
@@ -77,6 +86,11 @@ tender-raman-22cce2/
 │   │   └── [store.py](src/sessions/store.py)
 │   └── tools/
 │       ├── [__init__.py](src/tools/__init__.py)
+│       ├── __pycache__/
+│       │   ├── [__init__.cpython-312.pyc](src/tools/__pycache__/__init__.cpython-312.pyc)
+│       │   ├── [collections.cpython-312.pyc](src/tools/__pycache__/collections.cpython-312.pyc)
+│       │   ├── [export.cpython-312.pyc](src/tools/__pycache__/export.cpython-312.pyc)
+│       │   └── [qdrant_errors.cpython-312.pyc](src/tools/__pycache__/qdrant_errors.cpython-312.pyc)
 │       ├── [ai_patterns.py](src/tools/ai_patterns.py)
 │       ├── [collections.py](src/tools/collections.py)
 │       ├── [consistency.py](src/tools/consistency.py)
@@ -101,6 +115,13 @@ tender-raman-22cce2/
 │       └── [thesaurus.py](src/tools/thesaurus.py)
 ├── tests/
 │   ├── [__init__.py](tests/__init__.py)
+│   ├── __pycache__/
+│   │   ├── [__init__.cpython-312.pyc](tests/__pycache__/__init__.cpython-312.pyc)
+│   │   ├── [__init__.cpython-314.pyc](tests/__pycache__/__init__.cpython-314.pyc)
+│   │   ├── [conftest.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/conftest.cpython-312-pytest-9.0.2.pyc)
+│   │   ├── [conftest.cpython-314-pytest-9.0.2.pyc](tests/__pycache__/conftest.cpython-314-pytest-9.0.2.pyc)
+│   │   ├── [test_phase1_surface.cpython-312-pytest-9.0.2.pyc](tests/__pycache__/test_phase1_surface.cpython-312-pytest-9.0.2.pyc)
+│   │   └── [test_phase1_surface.cpython-314-pytest-9.0.2.pyc](tests/__pycache__/test_phase1_surface.cpython-314-pytest-9.0.2.pyc)
 │   ├── [conftest.py](tests/conftest.py)
 │   ├── [test_ai_patterns.py](tests/test_ai_patterns.py)
 │   ├── [test_collections.py](tests/test_collections.py)

--- a/src/server.py
+++ b/src/server.py
@@ -44,8 +44,9 @@ from src.models import (
     VocabularyFlagResult,
 )
 
-# ContextVar set by BearerAuthMiddleware from X-Client-ID header (gateway-injected)
+# ContextVars set by BearerAuthMiddleware from introspect response
 current_client_id: ContextVar[str | None] = ContextVar("current_client_id", default=None)
+current_is_admin: ContextVar[bool] = ContextVar("current_is_admin", default=False)
 
 
 def _client_id(ctx: Context) -> str:
@@ -61,13 +62,9 @@ def _client_id(ctx: Context) -> str:
 
 def _require_admin(ctx: Context) -> Optional[str]:
     """Return None if caller is admin, else an error string."""
-    admin_id = os.getenv("ADMIN_CLIENT_ID", "")
-    if not admin_id:
-        return "ADMIN_CLIENT_ID is not configured — admin tools are disabled"
-    caller = _client_id(ctx)
-    if caller != admin_id:
-        return f"Admin access required. Caller '{caller}' is not the configured admin."
-    return None
+    if current_is_admin.get(False):
+        return None
+    return "Admin access required."
 
 
 def _check_auth(token: str) -> bool:
@@ -89,16 +86,16 @@ def _oauth_introspect_url() -> str:
     return ""
 
 
-def _resolve_client_id_by_oauth_token(token: str) -> Optional[str]:
-    """Resolve tenant key via mcp-oauth-server /introspect.
+def _resolve_oauth_identity(token: str) -> tuple[Optional[str], bool]:
+    """Resolve tenant key and admin flag via mcp-oauth-server /introspect.
 
-    Prefers ``user_id`` (user-level tenancy, post-multi-device migration) and
-    falls back to ``client_id`` for legacy tokens issued before the migration.
+    Returns ``(client_id, is_admin)``. Prefers ``user_id`` (user-level tenancy,
+    post-multi-device migration) and falls back to ``client_id`` for legacy tokens.
     """
     introspect_url = _oauth_introspect_url()
     introspect_secret = os.getenv("INTROSPECT_SECRET", "").strip()
     if not token or not introspect_url or not introspect_secret:
-        return None
+        return None, False
     try:
         timeout_s = float(os.getenv("OAUTH_INTROSPECT_TIMEOUT", "3.0"))
         resp = requests.post(
@@ -108,17 +105,22 @@ def _resolve_client_id_by_oauth_token(token: str) -> Optional[str]:
             timeout=timeout_s,
         )
         if resp.status_code != 200:
-            return None
+            return None, False
         payload = resp.json()
         if not payload.get("active"):
-            return None
+            return None, False
         user_id = (payload.get("user_id") or "").strip()
-        if user_id:
-            return user_id
-        client_id = (payload.get("client_id") or "").strip()
-        return client_id or None
+        client_id = user_id or (payload.get("client_id") or "").strip() or None
+        is_admin = bool(payload.get("is_admin", False))
+        return client_id, is_admin
     except Exception:
-        return None
+        return None, False
+
+
+def _resolve_client_id_by_oauth_token(token: str) -> Optional[str]:
+    """Shim — returns only the client_id from _resolve_oauth_identity."""
+    client_id, _ = _resolve_oauth_identity(token)
+    return client_id
 
 
 class BearerAuthMiddleware:
@@ -135,7 +137,7 @@ class BearerAuthMiddleware:
             headers = dict(scope.get("headers", []))
             auth = headers.get(b"authorization", b"").decode()
             token = auth[7:] if auth.startswith("Bearer ") else ""
-            oauth_client_id = _resolve_client_id_by_oauth_token(token)
+            oauth_client_id, oauth_is_admin = _resolve_oauth_identity(token)
             if not (_check_auth(token) or oauth_client_id is not None):
                 import json as _json
                 body = _json.dumps({"error": "invalid_token", "error_description": "Authentication required"}).encode()
@@ -148,11 +150,13 @@ class BearerAuthMiddleware:
             user_id_hdr = headers.get(b"x-user-id", b"").decode().strip()
             client_id_hdr = headers.get(b"x-client-id", b"").decode().strip()
             client_id_val = user_id_hdr or client_id_hdr or oauth_client_id
-            ctx_token = current_client_id.set(client_id_val)
+            ctx_token_cid = current_client_id.set(client_id_val)
+            ctx_token_admin = current_is_admin.set(oauth_is_admin)
             try:
                 await self.app(scope, receive, send)
             finally:
-                current_client_id.reset(ctx_token)
+                current_client_id.reset(ctx_token_cid)
+                current_is_admin.reset(ctx_token_admin)
             return
         await self.app(scope, receive, send)
 
@@ -177,7 +181,7 @@ def _build_mcp() -> FastMCP:
         "writing-library://rubric-frameworks, writing-library://templates.\n\n"
         "Tenancy: per-user collections ({client_id}_writing_*) are isolated; thesaurus/rubrics/"
         "templates/terms_shared are shared. manage_term(share=True)/admin_add route to library "
-        "(admins) or the contribution queue (non-admins) based on ADMIN_CLIENT_ID. Use "
+        "(admins) or the contribution queue (non-admins) based on the caller's admin role. Use "
         "check_internal_similarity for your own library, check_external_similarity for the web via Tavily."
     )
     if transport == "http":
@@ -643,7 +647,7 @@ def manage_term(
     items: Optional[List[dict]] = None,
 ) -> dict:
     """
-    Manage terminology entries. add routes share→library|queue|personal based on ADMIN_CLIENT_ID.
+    Manage terminology entries. add routes share→library|queue|personal based on caller's admin role.
 
     Actions:
         add    — Add a term. Pass `preferred` (single) OR `items` (list).
@@ -992,8 +996,7 @@ def manage_contributions(
         Action-specific dict.
     """
     caller = _client_id(ctx)
-    admin_id = os.getenv("ADMIN_CLIENT_ID", "")
-    is_admin = bool(admin_id) and caller == admin_id
+    is_admin = _require_admin(ctx) is None
 
     if action == "list":
         from src.tools.contributions import list_contributions as _list
@@ -1050,6 +1053,11 @@ def manage_library(
     if action == "export":
         if not collection:
             return {"success": False, "error": "action='export' requires 'collection'"}
+        from src.tools.collections import get_core_collection_names
+        if collection in get_core_collection_names():
+            err = _require_admin(ctx)
+            if err:
+                return {"success": False, "error": err}
         from src.tools.export import export_library as _export
         return _export(collection=collection, output_format=output_format, client_id=client_id)
 

--- a/tests/test_phase1_surface.py
+++ b/tests/test_phase1_surface.py
@@ -494,3 +494,41 @@ def test_manage_library_invalid_action():
     out = server.manage_library(action="bogus", ctx=None)
     assert out["success"] is False
     assert "Invalid action" in out["error"]
+
+
+# export — core collection isolation
+# ---------------------------------------------------------------------------
+
+def test_manage_library_export_core_non_admin_blocked():
+    """Non-admin cannot export core collections (e.g. contributions)."""
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch.object(server, "_require_admin", return_value="Admin access required"):
+        out = server.manage_library(action="export", ctx=None, collection="contributions")
+    assert out["success"] is False
+    assert "Admin" in out["error"]
+
+
+def test_manage_library_export_core_admin_allowed():
+    """Admin can export core collections."""
+    with patch.object(server, "_client_id", return_value="admin"), \
+         patch.object(server, "_require_admin", return_value=None), \
+         patch("src.tools.export.export_library",
+               return_value={"success": True, "format": "json"}) as exporter:
+        out = server.manage_library(
+            action="export", ctx=None, collection="contributions", output_format="json",
+        )
+    assert out["success"] is True
+    exporter.assert_called_once()
+
+
+def test_manage_library_export_user_collection_non_admin_allowed():
+    """Non-admin can still export their own user collections."""
+    with patch.object(server, "_client_id", return_value="alice"), \
+         patch.object(server, "_require_admin", return_value="Admin access required"), \
+         patch("src.tools.export.export_library",
+               return_value={"success": True, "format": "json"}) as exporter:
+        out = server.manage_library(
+            action="export", ctx=None, collection="passages", output_format="json",
+        )
+    assert out["success"] is True
+    exporter.assert_called_once()


### PR DESCRIPTION
## Summary
- Replace ADMIN_CLIENT_ID(S) env-var allowlist with per-user is_admin flag sourced from the OAuth users table
- BearerAuthMiddleware reads is_admin from /introspect response and stores it in a current_is_admin ContextVar
- _require_admin() now checks the ContextVar instead of env vars
- _resolve_oauth_identity() replaces _resolve_client_id_by_oauth_token, returning (client_id, is_admin)
- manage_contribution inline ADMIN_CLIENT_ID check replaced with _require_admin
- 3 new export isolation tests: non-admins blocked from exporting core/shared collections (writing_contributions etc.)

## Why
Env-var allowlists do not scale beyond 1-2 admins and require Railway redeploys to grant/revoke. The OAuth User model already has is_admin: bool — surfacing it via introspect unlocks DB-driven admin management.

## Dependency
Requires mcp-oauth-server change to include is_admin in introspect response — landed in dsmoz/mcp-oauth-server@265e5a5.

## Test plan
- [x] python -m pytest tests/test_phase1_surface.py — 42 pass, 1 pre-existing failure unrelated to this PR
- [ ] Verify /introspect returns is_admin: true for usr_93f07c15894b4877 after Railway redeploy
- [ ] Call admin_add(kind="thesaurus", ...) as admin user — routes to library, not queue
- [ ] Same call as non-admin — returns Admin access required.
