### PR TITLE
fix(qdrant): missing keyword indexes on core collections + sparse-vector dedupe

### DIFF
--- a/src/tools/collections.py
+++ b/src/tools/collections.py
@@ -48,6 +48,26 @@ _PAYLOAD_KEYWORD_INDEXES: dict[str, tuple[str, ...]] = {
     "style_profiles": ("name", "channel"),
 }
 
+# Same requirement for core/shared collections. These are created by seed
+# scripts (not the per-user lazy path), and collections created before a
+# filter field was added never get its index from ensure_collection (which
+# returns early when the collection already exists). So patch them at runtime,
+# keyed by the field each core tool filters on:
+#   rubrics       — score_against_rubric filters framework + section
+#   templates     — check_structure filters framework + doc_type
+#   contributions — list/review filter status, target_collection,
+#                   contributed_by, contribution_id
+#   thesaurus / terms_shared — search filters language + domain
+# Creating an index is additive (it never reads or rewrites points), so this
+# is safe to run against a populated moderation queue.
+_CORE_PAYLOAD_KEYWORD_INDEXES: dict[str, tuple[str, ...]] = {
+    "rubrics": ("framework", "section", "entry_type"),
+    "templates": ("framework", "doc_type", "entry_type"),
+    "thesaurus": ("language", "domain", "entry_type"),
+    "terms_shared": ("language", "domain", "entry_type"),
+    "contributions": ("status", "target_collection", "contributed_by", "contribution_id", "entry_type"),
+}
+
 
 def get_core_collection_names() -> dict:
     """Return names for shared/core collections (not user-scoped).
@@ -199,6 +219,43 @@ def ensure_user_collections_once(client_id: str = "default") -> None:
         logger.warning("Could not ensure keyword payload indexes", error=str(e))
 
     _initialized_clients.add(client_id)
+
+
+_core_indexes_initialized = False
+
+
+def ensure_core_collection_indexes_once() -> None:
+    """Create keyword payload indexes on core/shared collections, once per process.
+
+    Idempotent: after the first successful pass, subsequent calls are no-ops.
+    Core collections (writing_rubrics, writing_templates, writing_contributions,
+    writing_thesaurus, writing_terms_shared) are created by seed scripts and so
+    bypass the per-user lazy index patch. Filtered queries against them (e.g.
+    score_against_rubric filtering ``framework``) fail with HTTP 400 unless the
+    field is indexed. Creating a payload index only adds an index — it never
+    reads, mutates, or deletes points — so this is safe on populated collections.
+    """
+    global _core_indexes_initialized
+    if _core_indexes_initialized:
+        return
+
+    try:
+        from kbase.vector.sync_client import get_qdrant_client
+
+        qc = get_qdrant_client()
+        core_collections = get_core_collection_names()
+        for collection_key, fields in _CORE_PAYLOAD_KEYWORD_INDEXES.items():
+            collection = core_collections.get(collection_key)
+            if not collection:
+                continue
+            for field in fields:
+                _ensure_keyword_index(qc, collection, field)
+        # Only latch the flag on a clean pass. If the client was transiently
+        # unreachable here, leave it unset so the migration retries on the next
+        # call rather than silently re-hiding the HTTP 400 it exists to fix.
+        _core_indexes_initialized = True
+    except Exception as e:
+        logger.warning("Could not ensure core keyword payload indexes", error=str(e))
 
 
 def get_stats(client_id: str = "default") -> dict:

--- a/src/tools/contributions.py
+++ b/src/tools/contributions.py
@@ -54,7 +54,8 @@ except ImportError:
 
 
 def _contributions_collection() -> str:
-    from src.tools.collections import get_core_collection_names
+    from src.tools.collections import get_core_collection_names, ensure_core_collection_indexes_once
+    ensure_core_collection_indexes_once()
     return get_core_collection_names()["contributions"]
 
 

--- a/src/tools/rubrics.py
+++ b/src/tools/rubrics.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import structlog
 
 from src.sentry import capture_tool_error
-from src.tools.collections import get_collection_names
+from src.tools.collections import get_collection_names, ensure_core_collection_indexes_once
 from src.tools.qdrant_errors import handle_qdrant_error
 
 logger = structlog.get_logger(__name__)
@@ -62,6 +62,7 @@ def add_rubric_criterion(
 
     document_id = str(uuid4())
     collection = get_collection_names()["rubrics"]
+    ensure_core_collection_indexes_once()
     title = f"[{framework.upper()} | {section}] {criterion[:60]}"
     metadata = {
         "framework": framework,
@@ -127,6 +128,7 @@ def score_against_rubric(
         return {"success": False, "error": "kbase library is not available"}
 
     collection = get_collection_names()["rubrics"]
+    ensure_core_collection_indexes_once()
 
     filter_conditions: dict = {"framework": framework}
     if section:

--- a/src/tools/templates.py
+++ b/src/tools/templates.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import structlog
 
 from src.sentry import capture_tool_error
-from src.tools.collections import get_collection_names
+from src.tools.collections import get_collection_names, ensure_core_collection_indexes_once
 from src.tools.qdrant_errors import handle_qdrant_error
 from src.tools.registry import VALID_DOC_TYPES
 
@@ -118,6 +118,7 @@ def add_template(framework: str, doc_type: str, sections: list) -> dict:
 
     document_id = str(uuid4())
     collection = get_collection_names()["templates"]
+    ensure_core_collection_indexes_once()
     title = f"[{framework.upper()} | {doc_type}] Template"
 
     # Concatenate section names + descriptions for embedding
@@ -193,6 +194,7 @@ def check_structure(text: str, framework: str, doc_type: str) -> dict:
         return {"success": False, "error": "kbase library is not available"}
 
     collection = get_collection_names()["templates"]
+    ensure_core_collection_indexes_once()
 
     # Retrieve the template
     try:

--- a/src/tools/terms.py
+++ b/src/tools/terms.py
@@ -113,8 +113,11 @@ def search_terms(
     Personal terms take precedence — if the same preferred term appears in both, the personal
     entry is returned and the shared duplicate is dropped.
     """
-    from src.tools.collections import get_core_collection_names
+    from src.tools.collections import get_core_collection_names, ensure_core_collection_indexes_once
     from src.tools.aliases import expand as _expand_alias
+
+    if include_shared:
+        ensure_core_collection_indexes_once()
 
     filter_conditions: dict = {}
     if domain:

--- a/src/tools/thesaurus.py
+++ b/src/tools/thesaurus.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import structlog
 
 from src.sentry import capture_tool_error
-from src.tools.collections import get_collection_names
+from src.tools.collections import get_collection_names, ensure_core_collection_indexes_once
 from src.tools.qdrant_errors import handle_qdrant_error
 from src.tools.registry import VALID_DOMAINS, VALID_LANGUAGES
 
@@ -154,6 +154,7 @@ def search_thesaurus(
         return {"success": False, "error": "query cannot be empty"}
 
     collection = get_collection_names()["thesaurus"]
+    ensure_core_collection_indexes_once()
     filter_conditions = {}
     if language:
         filter_conditions["language"] = language

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,14 @@
 """Shared test helpers for writing-library test suite."""
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock
+
+# Mirror main.py: make the project root and vendored kbase importable so tests
+# can import kbase.* directly (e.g. kbase.vector.sync_embeddings).
+_project_root = Path(__file__).resolve().parent.parent
+for _p in (_project_root, _project_root / "vendor"):
+    if _p.exists() and str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
 
 
 def _make_mock_point(payload: dict):

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -78,3 +78,66 @@ def test_ensure_user_collections_once_tolerates_existing_indexes():
     with patch.object(collections_mod, "setup_user_collections", return_value={}):
         with patch("kbase.vector.sync_client.get_qdrant_client", return_value=mock_client):
             collections_mod.ensure_user_collections_once("dup")  # must not raise
+
+
+def test_ensure_core_collection_indexes_once_creates_rubric_filter_indexes():
+    """Bug 1 regression: score_against_rubric filters framework + section on
+    writing_rubrics, which Qdrant rejects with HTTP 400 unless those fields are
+    keyword-indexed. Core collections are seeded outside the per-user lazy path,
+    so a dedicated runtime migration must create the indexes.
+    """
+    from src.tools import collections as collections_mod
+
+    collections_mod._core_indexes_initialized = False
+
+    mock_client = MagicMock()
+
+    with patch("kbase.vector.sync_client.get_qdrant_client", return_value=mock_client):
+        collections_mod.ensure_core_collection_indexes_once()
+
+    indexed = {
+        (call.kwargs["collection_name"], call.kwargs["field_name"])
+        for call in mock_client.create_payload_index.call_args_list
+    }
+
+    # The HTTP 400 from Sentry was on framework; section is the other filter on
+    # the same tool and must be covered too.
+    assert ("writing_rubrics", "framework") in indexed
+    assert ("writing_rubrics", "section") in indexed
+    # Other core collections that tools filter on are covered in the same pass.
+    assert ("writing_templates", "framework") in indexed
+    assert ("writing_templates", "doc_type") in indexed
+    assert ("writing_contributions", "status") in indexed
+    assert ("writing_contributions", "target_collection") in indexed
+    assert ("writing_terms_shared", "language") in indexed
+    assert ("writing_terms_shared", "domain") in indexed
+
+    # Flag latches after a clean pass, so the next call is a no-op.
+    assert collections_mod._core_indexes_initialized is True
+
+
+def test_ensure_core_collection_indexes_once_is_idempotent():
+    """Second call must not touch Qdrant once the flag is latched."""
+    from src.tools import collections as collections_mod
+
+    collections_mod._core_indexes_initialized = True  # already migrated
+
+    mock_client = MagicMock()
+    with patch("kbase.vector.sync_client.get_qdrant_client", return_value=mock_client):
+        collections_mod.ensure_core_collection_indexes_once()
+
+    mock_client.create_payload_index.assert_not_called()
+
+
+def test_ensure_core_collection_indexes_once_does_not_latch_on_failure():
+    """A transient Qdrant outage must leave the flag unset so the migration
+    retries on the next call instead of permanently re-hiding the HTTP 400.
+    """
+    from src.tools import collections as collections_mod
+
+    collections_mod._core_indexes_initialized = False
+
+    with patch("kbase.vector.sync_client.get_qdrant_client", side_effect=Exception("connection refused")):
+        collections_mod.ensure_core_collection_indexes_once()  # must not raise
+
+    assert collections_mod._core_indexes_initialized is False

--- a/tests/test_sparse_dedupe.py
+++ b/tests/test_sparse_dedupe.py
@@ -1,0 +1,79 @@
+"""
+Regression tests for sparse-vector index deduplication.
+
+Bug: admin_add / contribute upserts intermittently failed with Qdrant 422
+"[points[0].vector.?.indices: must be unique]". Root cause: distinct tokens
+collided onto the same index via ``hash(token) % SPARSE_HASH_MOD`` in
+generate_sparse_vector(); the salted hash() made it content- and run-dependent.
+Fix: dedupe_sparse() collapses colliding indices and sums their values before
+the sparse vector is returned (covering every collection that upserts).
+
+The criterion text below is the exact string that failed twice in production
+before succeeding on a shorter rephrase.
+"""
+import re
+
+from kbase.vector import sync_embeddings
+from kbase.vector.sync_embeddings import dedupe_sparse, generate_sparse_vector
+
+FAILING_CRITERION = (
+    "Presents ranked priorities, each structured as priority -> evidence -> "
+    "specific recommendation -> responsible actor (Global Fund, CCM, "
+    "government), traceable to dialogue findings."
+)
+
+
+def _strictly_increasing(xs) -> bool:
+    return all(a < b for a, b in zip(xs, xs[1:]))
+
+
+class TestDedupeSparse:
+    def test_collapses_duplicate_indices_summing_values(self):
+        idx, val = dedupe_sparse([5, 1, 5, 1, 5], [1.0, 2.0, 3.0, 4.0, 1.0])
+        assert idx == [1, 5]
+        assert val == [6.0, 5.0]  # index 1: 2+4, index 5: 1+3+1
+
+    def test_already_unique_returns_sorted(self):
+        idx, val = dedupe_sparse([3, 1, 2], [10.0, 20.0, 30.0])
+        assert idx == [1, 2, 3]
+        assert val == [20.0, 30.0, 10.0]
+
+    def test_empty(self):
+        assert dedupe_sparse([], []) == ([], [])
+
+    def test_output_unique_and_ascending(self):
+        idx, _ = dedupe_sparse([9, 9, 9, 4, 4, 1], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+        assert len(idx) == len(set(idx))
+        assert _strictly_increasing(idx)
+
+
+class TestGenerateSparseVector:
+    def test_failing_criterion_has_unique_indices(self):
+        indices, values = generate_sparse_vector(FAILING_CRITERION)
+        assert len(indices) == len(set(indices)), "indices must be unique (Qdrant 422 guard)"
+        assert len(indices) == len(values)
+        assert _strictly_increasing(indices)
+
+    def test_unique_even_under_forced_collisions(self, monkeypatch):
+        # Shrink the index space so distinct tokens are guaranteed to collide,
+        # making the regression deterministic regardless of PYTHONHASHSEED.
+        monkeypatch.setattr(sync_embeddings, "SPARSE_HASH_MOD", 4)
+        indices, values = generate_sparse_vector(FAILING_CRITERION)
+        assert indices == sorted(set(indices))
+        assert len(indices) == len(values)
+        assert all(v > 0 for v in values)
+        # No term-frequency mass is lost when colliding indices are merged.
+        raw_tokens = re.findall(r"\b[a-z0-9]{2,}\b", FAILING_CRITERION.lower())
+        assert sum(values) == float(len(raw_tokens))
+
+    def test_result_is_valid_qdrant_sparse_vector(self):
+        from qdrant_client.models import SparseVector
+
+        indices, values = generate_sparse_vector(FAILING_CRITERION)
+        sv = SparseVector(indices=indices, values=values)
+        assert len(sv.indices) == len(set(sv.indices))
+        assert len(sv.indices) == len(sv.values)
+
+    def test_empty_text_returns_empty(self):
+        assert generate_sparse_vector("") == ([], [])
+        assert generate_sparse_vector("   !!!  ") == ([], [])

--- a/vendor/kbase/vector/sync_embeddings.py
+++ b/vendor/kbase/vector/sync_embeddings.py
@@ -186,6 +186,38 @@ def generate_embeddings_batch(
     return all_embeddings
 
 
+# Sparse-vector index space. Token hashes are taken mod this value.
+SPARSE_HASH_MOD = 2**20  # ~1M possible indices
+
+
+def dedupe_sparse(
+    indices: List[int], values: List[float]
+) -> tuple[List[int], List[float]]:
+    """
+    Collapse duplicate sparse-vector indices, aggregating their values.
+
+    Qdrant rejects a SparseVector whose indices are not unique
+    (422: "indices: must be unique"). Distinct tokens can map to the same
+    index via hash collision (mod SPARSE_HASH_MOD), so any sparse vector
+    must be deduped before upsert/query. Colliding indices have their
+    values summed; the result is sorted by index for determinism.
+
+    Args:
+        indices: Sparse vector indices (may contain duplicates)
+        values: Parallel list of values
+
+    Returns:
+        (indices, values) with unique, ascending indices
+    """
+    from collections import defaultdict
+
+    agg: dict = defaultdict(float)
+    for i, v in zip(indices, values):
+        agg[i] += v
+    items = sorted(agg.items())
+    return [i for i, _ in items], [v for _, v in items]
+
+
 def generate_sparse_vector(text: str) -> tuple[List[int], List[float]]:
     """
     Generate a sparse vector for BM25-style keyword search.
@@ -197,7 +229,8 @@ def generate_sparse_vector(text: str) -> tuple[List[int], List[float]]:
         text: Text to convert to sparse vector
 
     Returns:
-        Tuple of (indices, values) for sparse vector
+        Tuple of (indices, values) for sparse vector. Indices are unique
+        and ascending (deduped against hash collisions).
     """
     import re
     from collections import Counter
@@ -211,20 +244,18 @@ def generate_sparse_vector(text: str) -> tuple[List[int], List[float]]:
     # Count term frequencies
     term_counts = Counter(tokens)
 
-    # Convert to sparse vector format
-    # Use hash of token as index (mod large prime for reasonable index range)
-    HASH_MOD = 2**20  # ~1M possible indices
-
     indices = []
     values = []
 
     for token, count in term_counts.items():
         # Use hash of token as index
-        token_hash = hash(token) % HASH_MOD
+        token_hash = hash(token) % SPARSE_HASH_MOD
         indices.append(token_hash)
         values.append(float(count))
 
-    return indices, values
+    # Distinct tokens can collide onto the same index mod SPARSE_HASH_MOD.
+    # Qdrant requires unique indices, so dedupe before returning.
+    return dedupe_sparse(indices, values)
 
 
 def generate_sparse_vectors_batch(texts: List[str]) -> List[tuple[List[int], List[float]]]:

--- a/vendor/kbase/vector/sync_indexing.py
+++ b/vendor/kbase/vector/sync_indexing.py
@@ -666,15 +666,26 @@ def ensure_collection(
                 mode="dense only",
             )
 
-        # Create payload indexes for filterable fields
+        # Create payload indexes for every field any tool filters on. Qdrant
+        # raises HTTP 400 ("Index required but not found") on a filter against
+        # an unindexed field, so index the full superset across all collection
+        # types up front. Indexing a field absent from a given collection is a
+        # cheap no-op, so over-indexing here is harmless.
         from qdrant_client.models import PayloadSchemaType
-        for field in ("language", "domain", "doc_type", "name", "channel", "client_id"):
+        index_fields = (
+            "language", "domain", "doc_type", "name", "channel", "client_id",
+            # rubrics / templates filter fields
+            "framework", "section", "rubric_section", "entry_type",
+            # contributions (moderation queue) filter fields
+            "status", "target_collection", "contributed_by", "contribution_id",
+        )
+        for field in index_fields:
             client.create_payload_index(
                 collection_name=collection_name,
                 field_name=field,
                 field_schema=PayloadSchemaType.KEYWORD,
             )
-        logger.info("Payload indexes created", collection=collection_name)
+        logger.info("Payload indexes created", collection=collection_name, count=len(index_fields))
 
         return True
 


### PR DESCRIPTION
## Summary

Fixes two production bugs surfaced via the DS-MOZ gateway.

### Bug 1 — HTTP 400 `Index required but not found for "framework"` (High)

`score_against_rubric` filters `framework` + `section` on the shared
`writing_rubrics` collection, but those fields were never keyword-indexed.
Root cause: `ensure_collection` early-returns for collections that already
exist, so seed-created core collections bypass the per-user lazy index patch
and never pick up indexes for newly-filtered fields.

**Fix**
- Expand the creation-time index loop in `ensure_collection`
  (`vendor/kbase/vector/sync_indexing.py`) so new collections index every
  filtered field.
- Add `ensure_core_collection_indexes_once()` runtime migration
  (`src/tools/collections.py`) for collections that already exist in prod.
  Wired into every core-collection tool entry point: rubrics, templates,
  thesaurus, terms, contributions.
- The done-flag latches **only on a clean pass**, so a transient Qdrant
  outage retries on the next call instead of permanently re-hiding the 400.
- Index creation is purely additive — never reads, mutates, or deletes
  points. Safe on the populated moderation queue (8 pending `global-fund`
  contributions untouched).

### Bug 2 — HTTP 422 `indices: must be unique` (Medium, intermittent)

Sparse-vector upsert rejects duplicate indices. Distinct tokens collide onto
the same index via `hash(token) % 2**20`; salted `PYTHONHASHSEED` makes the
collision content-dependent, which matches the intermittent symptom.

**Fix**
- Add `dedupe_sparse()` and call it at the single construction point
  `generate_sparse_vector` (`vendor/kbase/vector/sync_embeddings.py`) — covers
  all collections, both upsert and query. Colliding indices have their values
  summed; result is sorted ascending for determinism.

## Tests

- `tests/test_sparse_dedupe.py` — 8 tests, incl. the exact production failure
  string and a forced-collision mass-preservation check.
- `tests/test_collections.py` — core-index creation (framework + section +
  other core fields), idempotency, and does-not-latch-on-failure.
- `tests/conftest.py` — add vendored-kbase `sys.path` setup mirroring `main.py`.

**Suite: 384 passed, 6 failed.** The 6 failures are pre-existing and unrelated
(baseline-confirmed via `git stash` on untouched main) — 4× `test_transport.py`
`BearerTokenVerifier` ImportError from `src.server`, plus `test_styles.py` and
`test_phase1_surface.py`. None touch files changed here.

## Reviewer notes

- **Bug 1 fix is lazy.** The runtime migration executes on the first
  core-collection tool call per process (i.e. on next deploy / first real
  `score_against_rubric` call), not eagerly. It is verified by mocked unit
  tests only — **not** live-verified against the production Qdrant instance.
- The 6 pre-existing suite failures are out of scope here; flag if you want
  them addressed separately.