### PR TITLE
fix(admin+contributions): X-Is-Admin header reader + chunk-twin collapse

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -194,8 +194,14 @@ class BearerAuthMiddleware:
             user_id_hdr = headers.get(b"x-user-id", b"").decode().strip()
             client_id_hdr = headers.get(b"x-client-id", b"").decode().strip()
             client_id_val = user_id_hdr or client_id_hdr or oauth_client_id
+            # Admin status: in gateway-routed mode the Authorization bearer is the
+            # shared upstream API key, not the user's token, so introspecting it
+            # never yields the caller's admin flag. The gateway resolves it and
+            # forwards X-Is-Admin (mirroring the X-User-ID tenancy header). Fall
+            # back to the introspected token for direct, non-gateway callers.
+            is_admin_hdr = headers.get(b"x-is-admin", b"").decode().strip().lower() == "true"
             ctx_token_cid = current_client_id.set(client_id_val)
-            ctx_token_admin = current_is_admin.set(oauth_is_admin)
+            ctx_token_admin = current_is_admin.set(is_admin_hdr or oauth_is_admin)
             try:
                 await self.app(scope, receive, send)
             finally:

--- a/src/tools/collections.py
+++ b/src/tools/collections.py
@@ -48,6 +48,26 @@ _PAYLOAD_KEYWORD_INDEXES: dict[str, tuple[str, ...]] = {
     "style_profiles": ("name", "channel"),
 }
 
+# Same requirement for core/shared collections. These are created by seed
+# scripts (not the per-user lazy path), and collections created before a
+# filter field was added never get its index from ensure_collection (which
+# returns early when the collection already exists). So patch them at runtime,
+# keyed by the field each core tool filters on:
+#   rubrics       — score_against_rubric filters framework + section
+#   templates     — check_structure filters framework + doc_type
+#   contributions — list/review filter status, target_collection,
+#                   contributed_by, contribution_id
+#   thesaurus / terms_shared — search filters language + domain
+# Creating an index is additive (it never reads or rewrites points), so this
+# is safe to run against a populated moderation queue.
+_CORE_PAYLOAD_KEYWORD_INDEXES: dict[str, tuple[str, ...]] = {
+    "rubrics": ("framework", "section", "entry_type"),
+    "templates": ("framework", "doc_type", "entry_type"),
+    "thesaurus": ("language", "domain", "entry_type"),
+    "terms_shared": ("language", "domain", "entry_type"),
+    "contributions": ("status", "target_collection", "contributed_by", "contribution_id", "entry_type"),
+}
+
 
 def get_core_collection_names() -> dict:
     """Return names for shared/core collections (not user-scoped).
@@ -199,6 +219,43 @@ def ensure_user_collections_once(client_id: str = "default") -> None:
         logger.warning("Could not ensure keyword payload indexes", error=str(e))
 
     _initialized_clients.add(client_id)
+
+
+_core_indexes_initialized = False
+
+
+def ensure_core_collection_indexes_once() -> None:
+    """Create keyword payload indexes on core/shared collections, once per process.
+
+    Idempotent: after the first successful pass, subsequent calls are no-ops.
+    Core collections (writing_rubrics, writing_templates, writing_contributions,
+    writing_thesaurus, writing_terms_shared) are created by seed scripts and so
+    bypass the per-user lazy index patch. Filtered queries against them (e.g.
+    score_against_rubric filtering ``framework``) fail with HTTP 400 unless the
+    field is indexed. Creating a payload index only adds an index — it never
+    reads, mutates, or deletes points — so this is safe on populated collections.
+    """
+    global _core_indexes_initialized
+    if _core_indexes_initialized:
+        return
+
+    try:
+        from kbase.vector.sync_client import get_qdrant_client
+
+        qc = get_qdrant_client()
+        core_collections = get_core_collection_names()
+        for collection_key, fields in _CORE_PAYLOAD_KEYWORD_INDEXES.items():
+            collection = core_collections.get(collection_key)
+            if not collection:
+                continue
+            for field in fields:
+                _ensure_keyword_index(qc, collection, field)
+        # Only latch the flag on a clean pass. If the client was transiently
+        # unreachable here, leave it unset so the migration retries on the next
+        # call rather than silently re-hiding the HTTP 400 it exists to fix.
+        _core_indexes_initialized = True
+    except Exception as e:
+        logger.warning("Could not ensure core keyword payload indexes", error=str(e))
 
 
 def get_stats(client_id: str = "default") -> dict:

--- a/src/tools/contributions.py
+++ b/src/tools/contributions.py
@@ -233,33 +233,50 @@ def list_contributions(
 
         scroll_filter = Filter(must=must_conditions) if must_conditions else None
 
-        results, _ = client.scroll(
-            collection_name=_contributions_collection(),
-            scroll_filter=scroll_filter,
-            limit=limit,
-            with_payload=True,
-            with_vectors=False,
-        )
+        # A single contribution is stored as one Qdrant point per content chunk
+        # (index_document chunks the entry), so a multi-chunk entry has several
+        # points sharing one contribution_id. Page through ALL matching points
+        # and collapse by contribution_id so callers see logical contributions,
+        # not raw chunks. `limit` then bounds logical contributions, not points.
+        seen: dict = {}
+        offset = None
+        while True:
+            results, offset = client.scroll(
+                collection_name=_contributions_collection(),
+                scroll_filter=scroll_filter,
+                limit=256,
+                offset=offset,
+                with_payload=True,
+                with_vectors=False,
+            )
+            for point in results:
+                p = point.payload or {}
+                # Fall back to the point id when contribution_id is missing so a
+                # malformed legacy point still surfaces instead of vanishing.
+                cid = p.get("contribution_id") or f"_pt_{point.id}"
+                if cid in seen:
+                    continue
+                seen[cid] = {
+                    "contribution_id": p.get("contribution_id"),
+                    "contributed_by": p.get("contributed_by"),
+                    "target": p.get("target_collection"),
+                    "status": p.get("status"),
+                    "submitted_at": p.get("submitted_at"),
+                    "reviewed_at": p.get("reviewed_at"),
+                    "reviewed_by": p.get("reviewed_by"),
+                    "rejection_reason": p.get("rejection_reason"),
+                    "note": p.get("note", ""),
+                    "payload": json.loads(p.get("payload_json", "{}")),
+                }
+            if offset is None:
+                break
 
-        contributions = []
-        for point in results:
-            p = point.payload or {}
-            entry = {
-                "contribution_id": p.get("contribution_id"),
-                "contributed_by": p.get("contributed_by"),
-                "target": p.get("target_collection"),
-                "status": p.get("status"),
-                "submitted_at": p.get("submitted_at"),
-                "reviewed_at": p.get("reviewed_at"),
-                "reviewed_by": p.get("reviewed_by"),
-                "rejection_reason": p.get("rejection_reason"),
-                "note": p.get("note", ""),
-                "payload": json.loads(p.get("payload_json", "{}")),
-            }
-            contributions.append(entry)
+        contributions = list(seen.values())
 
-        # Sort by submitted_at descending
+        # Sort by submitted_at descending, then bound to the requested limit.
         contributions.sort(key=lambda x: x.get("submitted_at") or "", reverse=True)
+        if limit is not None and limit > 0:
+            contributions = contributions[:limit]
 
         return {"success": True, "contributions": contributions, "total": len(contributions)}
 
@@ -308,23 +325,33 @@ def review_contribution(
 
     try:
         client = get_qdrant_client()
-        results, _ = client.scroll(
-            collection_name=_contributions_collection(),
-            scroll_filter=Filter(
-                must=[FieldCondition(
-                    key="contribution_id", match=MatchValue(value=contribution_id)
-                )]
-            ),
-            limit=1,
-            with_payload=True,
-            with_vectors=False,
-        )
+        # A contribution may span several Qdrant points (one per content chunk)
+        # that share contribution_id. Page through ALL of them so the status
+        # flip covers every twin — flipping only one leaves orphan points stuck
+        # at "pending" that resurface in the queue.
+        points = []
+        offset = None
+        while True:
+            batch, offset = client.scroll(
+                collection_name=_contributions_collection(),
+                scroll_filter=Filter(
+                    must=[FieldCondition(
+                        key="contribution_id", match=MatchValue(value=contribution_id)
+                    )]
+                ),
+                limit=256,
+                offset=offset,
+                with_payload=True,
+                with_vectors=False,
+            )
+            points.extend(batch)
+            if offset is None:
+                break
 
-        if not results:
+        if not points:
             return {"success": False, "error": f"Contribution '{contribution_id}' not found"}
 
-        point = results[0]
-        p = point.payload or {}
+        p = points[0].payload or {}
 
         if p.get("status") != "pending":
             return {
@@ -336,7 +363,7 @@ def review_contribution(
         payload = json.loads(p.get("payload_json", "{}"))
         now = _now_iso()
 
-        # Update the contribution record status
+        # Flip status on every twin point in one call.
         client.set_payload(
             collection_name=_contributions_collection(),
             payload={
@@ -345,9 +372,10 @@ def review_contribution(
                 "reviewed_by": reviewed_by,
                 "rejection_reason": rejection_reason if action == "reject" else None,
             },
-            points=[point.id],
+            points=[pt.id for pt in points],
         )
 
+        # Publish exactly once regardless of how many points back the entry.
         if action == "publish":
             _publish_to_shared(target, payload, contribution_id)
 

--- a/src/tools/contributions.py
+++ b/src/tools/contributions.py
@@ -54,7 +54,8 @@ except ImportError:
 
 
 def _contributions_collection() -> str:
-    from src.tools.collections import get_core_collection_names
+    from src.tools.collections import get_core_collection_names, ensure_core_collection_indexes_once
+    ensure_core_collection_indexes_once()
     return get_core_collection_names()["contributions"]
 
 

--- a/src/tools/rubrics.py
+++ b/src/tools/rubrics.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import structlog
 
 from src.sentry import capture_tool_error
-from src.tools.collections import get_collection_names
+from src.tools.collections import get_collection_names, ensure_core_collection_indexes_once
 from src.tools.qdrant_errors import handle_qdrant_error
 
 logger = structlog.get_logger(__name__)
@@ -62,6 +62,7 @@ def add_rubric_criterion(
 
     document_id = str(uuid4())
     collection = get_collection_names()["rubrics"]
+    ensure_core_collection_indexes_once()
     title = f"[{framework.upper()} | {section}] {criterion[:60]}"
     metadata = {
         "framework": framework,
@@ -127,6 +128,7 @@ def score_against_rubric(
         return {"success": False, "error": "kbase library is not available"}
 
     collection = get_collection_names()["rubrics"]
+    ensure_core_collection_indexes_once()
 
     filter_conditions: dict = {"framework": framework}
     if section:

--- a/src/tools/templates.py
+++ b/src/tools/templates.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import structlog
 
 from src.sentry import capture_tool_error
-from src.tools.collections import get_collection_names
+from src.tools.collections import get_collection_names, ensure_core_collection_indexes_once
 from src.tools.qdrant_errors import handle_qdrant_error
 from src.tools.registry import VALID_DOC_TYPES
 
@@ -118,6 +118,7 @@ def add_template(framework: str, doc_type: str, sections: list) -> dict:
 
     document_id = str(uuid4())
     collection = get_collection_names()["templates"]
+    ensure_core_collection_indexes_once()
     title = f"[{framework.upper()} | {doc_type}] Template"
 
     # Concatenate section names + descriptions for embedding
@@ -193,6 +194,7 @@ def check_structure(text: str, framework: str, doc_type: str) -> dict:
         return {"success": False, "error": "kbase library is not available"}
 
     collection = get_collection_names()["templates"]
+    ensure_core_collection_indexes_once()
 
     # Retrieve the template
     try:

--- a/src/tools/terms.py
+++ b/src/tools/terms.py
@@ -113,8 +113,11 @@ def search_terms(
     Personal terms take precedence — if the same preferred term appears in both, the personal
     entry is returned and the shared duplicate is dropped.
     """
-    from src.tools.collections import get_core_collection_names
+    from src.tools.collections import get_core_collection_names, ensure_core_collection_indexes_once
     from src.tools.aliases import expand as _expand_alias
+
+    if include_shared:
+        ensure_core_collection_indexes_once()
 
     filter_conditions: dict = {}
     if domain:

--- a/src/tools/thesaurus.py
+++ b/src/tools/thesaurus.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import structlog
 
 from src.sentry import capture_tool_error
-from src.tools.collections import get_collection_names
+from src.tools.collections import get_collection_names, ensure_core_collection_indexes_once
 from src.tools.qdrant_errors import handle_qdrant_error
 from src.tools.registry import VALID_DOMAINS, VALID_LANGUAGES
 
@@ -154,6 +154,7 @@ def search_thesaurus(
         return {"success": False, "error": "query cannot be empty"}
 
     collection = get_collection_names()["thesaurus"]
+    ensure_core_collection_indexes_once()
     filter_conditions = {}
     if language:
         filter_conditions["language"] = language

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,14 @@
 """Shared test helpers for writing-library test suite."""
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock
+
+# Mirror main.py: make the project root and vendored kbase importable so tests
+# can import kbase.* directly (e.g. kbase.vector.sync_embeddings).
+_project_root = Path(__file__).resolve().parent.parent
+for _p in (_project_root, _project_root / "vendor"):
+    if _p.exists() and str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
 
 
 def _make_mock_point(payload: dict):

--- a/tests/test_admin_header.py
+++ b/tests/test_admin_header.py
@@ -1,0 +1,88 @@
+"""BearerAuthMiddleware admin-flag resolution.
+
+Gateway-routed mode: the Authorization bearer is the shared upstream API key,
+not the user's token, so introspecting it never yields the caller's admin flag.
+The gateway resolves admin status and forwards X-Is-Admin (mirroring the
+X-User-ID tenancy header). These tests pin that the middleware honours the
+header and falls back safely when it is absent.
+"""
+import asyncio
+
+import pytest
+
+from src import server as srv
+
+
+def _drive_middleware(headers):
+    """Run BearerAuthMiddleware over a fake ASGI request, capturing the
+    ContextVar values visible to the downstream app (they reset on exit)."""
+    captured: dict = {}
+
+    async def app(scope, receive, send):
+        captured["is_admin"] = srv.current_is_admin.get()
+        captured["client_id"] = srv.current_client_id.get()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    sent: list = []
+
+    async def send(message):
+        sent.append(message)
+
+    scope = {"type": "http", "path": "/mcp", "headers": headers}
+    asyncio.run(srv.BearerAuthMiddleware(app)(scope, receive, send))
+    return captured, sent
+
+
+@pytest.fixture(autouse=True)
+def _no_auth_env(monkeypatch):
+    # API_TOKENS unset → allow-all; introspect unset → no network, oauth admin False.
+    monkeypatch.delenv("API_TOKENS", raising=False)
+    monkeypatch.delenv("OAUTH_INTROSPECT_URL", raising=False)
+    monkeypatch.delenv("OAUTH_ISSUER_URL", raising=False)
+    monkeypatch.delenv("INTROSPECT_SECRET", raising=False)
+
+
+def test_x_is_admin_true_grants_admin():
+    headers = [
+        (b"authorization", b"Bearer gateway-shared-key"),
+        (b"x-user-id", b"usr_93f07c15894b4877"),
+        (b"x-is-admin", b"true"),
+    ]
+    captured, _ = _drive_middleware(headers)
+    assert captured["is_admin"] is True
+    # Tenancy still resolves from X-User-ID, independent of the admin flag.
+    assert captured["client_id"] == "usr_93f07c15894b4877"
+
+
+def test_missing_header_defaults_non_admin():
+    headers = [
+        (b"authorization", b"Bearer gateway-shared-key"),
+        (b"x-user-id", b"usr_93f07c15894b4877"),
+    ]
+    captured, _ = _drive_middleware(headers)
+    assert captured["is_admin"] is False
+
+
+def test_x_is_admin_false_is_non_admin():
+    headers = [
+        (b"authorization", b"Bearer gateway-shared-key"),
+        (b"x-user-id", b"usr_someone"),
+        (b"x-is-admin", b"false"),
+    ]
+    captured, _ = _drive_middleware(headers)
+    assert captured["is_admin"] is False
+
+
+def test_admin_flag_resets_after_request():
+    """ContextVar must not leak across requests."""
+    _drive_middleware([
+        (b"authorization", b"Bearer k"),
+        (b"x-user-id", b"usr_admin"),
+        (b"x-is-admin", b"true"),
+    ])
+    # Outside any request, the default is non-admin.
+    assert srv.current_is_admin.get() is False

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -78,3 +78,66 @@ def test_ensure_user_collections_once_tolerates_existing_indexes():
     with patch.object(collections_mod, "setup_user_collections", return_value={}):
         with patch("kbase.vector.sync_client.get_qdrant_client", return_value=mock_client):
             collections_mod.ensure_user_collections_once("dup")  # must not raise
+
+
+def test_ensure_core_collection_indexes_once_creates_rubric_filter_indexes():
+    """Bug 1 regression: score_against_rubric filters framework + section on
+    writing_rubrics, which Qdrant rejects with HTTP 400 unless those fields are
+    keyword-indexed. Core collections are seeded outside the per-user lazy path,
+    so a dedicated runtime migration must create the indexes.
+    """
+    from src.tools import collections as collections_mod
+
+    collections_mod._core_indexes_initialized = False
+
+    mock_client = MagicMock()
+
+    with patch("kbase.vector.sync_client.get_qdrant_client", return_value=mock_client):
+        collections_mod.ensure_core_collection_indexes_once()
+
+    indexed = {
+        (call.kwargs["collection_name"], call.kwargs["field_name"])
+        for call in mock_client.create_payload_index.call_args_list
+    }
+
+    # The HTTP 400 from Sentry was on framework; section is the other filter on
+    # the same tool and must be covered too.
+    assert ("writing_rubrics", "framework") in indexed
+    assert ("writing_rubrics", "section") in indexed
+    # Other core collections that tools filter on are covered in the same pass.
+    assert ("writing_templates", "framework") in indexed
+    assert ("writing_templates", "doc_type") in indexed
+    assert ("writing_contributions", "status") in indexed
+    assert ("writing_contributions", "target_collection") in indexed
+    assert ("writing_terms_shared", "language") in indexed
+    assert ("writing_terms_shared", "domain") in indexed
+
+    # Flag latches after a clean pass, so the next call is a no-op.
+    assert collections_mod._core_indexes_initialized is True
+
+
+def test_ensure_core_collection_indexes_once_is_idempotent():
+    """Second call must not touch Qdrant once the flag is latched."""
+    from src.tools import collections as collections_mod
+
+    collections_mod._core_indexes_initialized = True  # already migrated
+
+    mock_client = MagicMock()
+    with patch("kbase.vector.sync_client.get_qdrant_client", return_value=mock_client):
+        collections_mod.ensure_core_collection_indexes_once()
+
+    mock_client.create_payload_index.assert_not_called()
+
+
+def test_ensure_core_collection_indexes_once_does_not_latch_on_failure():
+    """A transient Qdrant outage must leave the flag unset so the migration
+    retries on the next call instead of permanently re-hiding the HTTP 400.
+    """
+    from src.tools import collections as collections_mod
+
+    collections_mod._core_indexes_initialized = False
+
+    with patch("kbase.vector.sync_client.get_qdrant_client", side_effect=Exception("connection refused")):
+        collections_mod.ensure_core_collection_indexes_once()  # must not raise
+
+    assert collections_mod._core_indexes_initialized is False

--- a/tests/test_contributions_dedup.py
+++ b/tests/test_contributions_dedup.py
@@ -1,0 +1,132 @@
+"""Contribution chunk-collapse and twin-flip regression tests.
+
+A single contribution is indexed as one Qdrant point per content chunk, so a
+multi-chunk entry is stored as several points sharing one contribution_id
+(byte-identical payloads). Two bugs followed from treating points as entries:
+
+  * ``list_contributions`` returned one row per point — a 2-chunk entry showed
+    up twice, inflating the queue (139 rows for 94 logical contributions).
+  * ``review_contribution`` scrolled with ``limit=1`` and flipped a single
+    point, leaving the twin stuck at "pending" so it resurfaced in the queue;
+    publishing still happened once, but the entry never cleared.
+
+These tests pin the collapse (list) and the flip-all-publish-once (review).
+"""
+import json
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import src.tools.contributions  # noqa: F401 — register submodule for patch paths
+
+
+def _point(point_id, payload):
+    return SimpleNamespace(id=point_id, payload=payload)
+
+
+def _twin_payload(cid, status="pending"):
+    """Two byte-identical chunk points share this payload (different point id)."""
+    return {
+        "contribution_id": cid,
+        "contributed_by": "usr_x",
+        "target_collection": "rubrics",
+        "status": status,
+        "submitted_at": "2026-05-13T10:00:00Z",
+        "payload_json": json.dumps({"framework": "global-fund", "criterion": "c1"}),
+    }
+
+
+def _client_returning(points):
+    client = MagicMock()
+    client.scroll.return_value = (points, None)  # offset None terminates the page loop
+    return client
+
+
+# ---------------------------------------------------------------------------
+# list_contributions — collapse by contribution_id
+# ---------------------------------------------------------------------------
+
+def test_list_collapses_twin_points_to_one_row():
+    cid = "11111111-1111-1111-1111-111111111111"
+    points = [_point("pt-a", _twin_payload(cid)), _point("pt-b", _twin_payload(cid))]
+    with patch("src.tools.contributions.get_qdrant_client", return_value=_client_returning(points)), \
+         patch("src.tools.contributions._contributions_collection", return_value="writing_contributions"):
+        from src.tools.contributions import list_contributions
+        out = list_contributions(status="pending")
+    assert out["success"] is True
+    assert out["total"] == 1
+    assert out["contributions"][0]["contribution_id"] == cid
+
+
+def test_list_distinct_ids_each_kept():
+    points = [
+        _point("pt-a", _twin_payload("aaaa")),
+        _point("pt-b", _twin_payload("aaaa")),  # twin of aaaa
+        _point("pt-c", _twin_payload("bbbb")),
+    ]
+    with patch("src.tools.contributions.get_qdrant_client", return_value=_client_returning(points)), \
+         patch("src.tools.contributions._contributions_collection", return_value="writing_contributions"):
+        from src.tools.contributions import list_contributions
+        out = list_contributions(status="pending")
+    assert out["total"] == 2
+    assert {c["contribution_id"] for c in out["contributions"]} == {"aaaa", "bbbb"}
+
+
+def test_list_limit_bounds_logical_contributions():
+    points = [_point(f"pt-{i}", _twin_payload(f"id-{i}")) for i in range(5)]
+    with patch("src.tools.contributions.get_qdrant_client", return_value=_client_returning(points)), \
+         patch("src.tools.contributions._contributions_collection", return_value="writing_contributions"):
+        from src.tools.contributions import list_contributions
+        out = list_contributions(status="pending", limit=2)
+    assert out["total"] == 2
+
+
+# ---------------------------------------------------------------------------
+# review_contribution — flip all twins, publish once
+# ---------------------------------------------------------------------------
+
+def test_review_flips_all_twins_and_publishes_once():
+    cid = "22222222-2222-2222-2222-222222222222"
+    points = [_point("pt-a", _twin_payload(cid)), _point("pt-b", _twin_payload(cid))]
+    client = _client_returning(points)
+    with patch("src.tools.contributions.get_qdrant_client", return_value=client), \
+         patch("src.tools.contributions.index_document", MagicMock()), \
+         patch("src.tools.contributions._contributions_collection", return_value="writing_contributions"), \
+         patch("src.tools.contributions._publish_to_shared") as publish:
+        from src.tools.contributions import review_contribution
+        out = review_contribution(cid, action="publish", reviewed_by="admin")
+
+    assert out["success"] is True
+    # set_payload called once, covering BOTH twin point ids.
+    client.set_payload.assert_called_once()
+    flipped = client.set_payload.call_args.kwargs["points"]
+    assert set(flipped) == {"pt-a", "pt-b"}
+    assert client.set_payload.call_args.kwargs["payload"]["status"] == "published"
+    # Publish to the shared collection happens exactly once, not per twin.
+    publish.assert_called_once()
+
+
+def test_review_already_reviewed_is_rejected():
+    cid = "33333333-3333-3333-3333-333333333333"
+    points = [_point("pt-a", _twin_payload(cid, status="published"))]
+    client = _client_returning(points)
+    with patch("src.tools.contributions.get_qdrant_client", return_value=client), \
+         patch("src.tools.contributions.index_document", MagicMock()), \
+         patch("src.tools.contributions._contributions_collection", return_value="writing_contributions"), \
+         patch("src.tools.contributions._publish_to_shared") as publish:
+        from src.tools.contributions import review_contribution
+        out = review_contribution(cid, action="publish", reviewed_by="admin")
+    assert out["success"] is False
+    assert "already" in out["error"]
+    publish.assert_not_called()
+    client.set_payload.assert_not_called()
+
+
+def test_review_missing_contribution():
+    client = _client_returning([])
+    with patch("src.tools.contributions.get_qdrant_client", return_value=client), \
+         patch("src.tools.contributions.index_document", MagicMock()), \
+         patch("src.tools.contributions._contributions_collection", return_value="writing_contributions"):
+        from src.tools.contributions import review_contribution
+        out = review_contribution("nope", action="publish", reviewed_by="admin")
+    assert out["success"] is False
+    assert "not found" in out["error"]

--- a/tests/test_sparse_dedupe.py
+++ b/tests/test_sparse_dedupe.py
@@ -1,0 +1,79 @@
+"""
+Regression tests for sparse-vector index deduplication.
+
+Bug: admin_add / contribute upserts intermittently failed with Qdrant 422
+"[points[0].vector.?.indices: must be unique]". Root cause: distinct tokens
+collided onto the same index via ``hash(token) % SPARSE_HASH_MOD`` in
+generate_sparse_vector(); the salted hash() made it content- and run-dependent.
+Fix: dedupe_sparse() collapses colliding indices and sums their values before
+the sparse vector is returned (covering every collection that upserts).
+
+The criterion text below is the exact string that failed twice in production
+before succeeding on a shorter rephrase.
+"""
+import re
+
+from kbase.vector import sync_embeddings
+from kbase.vector.sync_embeddings import dedupe_sparse, generate_sparse_vector
+
+FAILING_CRITERION = (
+    "Presents ranked priorities, each structured as priority -> evidence -> "
+    "specific recommendation -> responsible actor (Global Fund, CCM, "
+    "government), traceable to dialogue findings."
+)
+
+
+def _strictly_increasing(xs) -> bool:
+    return all(a < b for a, b in zip(xs, xs[1:]))
+
+
+class TestDedupeSparse:
+    def test_collapses_duplicate_indices_summing_values(self):
+        idx, val = dedupe_sparse([5, 1, 5, 1, 5], [1.0, 2.0, 3.0, 4.0, 1.0])
+        assert idx == [1, 5]
+        assert val == [6.0, 5.0]  # index 1: 2+4, index 5: 1+3+1
+
+    def test_already_unique_returns_sorted(self):
+        idx, val = dedupe_sparse([3, 1, 2], [10.0, 20.0, 30.0])
+        assert idx == [1, 2, 3]
+        assert val == [20.0, 30.0, 10.0]
+
+    def test_empty(self):
+        assert dedupe_sparse([], []) == ([], [])
+
+    def test_output_unique_and_ascending(self):
+        idx, _ = dedupe_sparse([9, 9, 9, 4, 4, 1], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+        assert len(idx) == len(set(idx))
+        assert _strictly_increasing(idx)
+
+
+class TestGenerateSparseVector:
+    def test_failing_criterion_has_unique_indices(self):
+        indices, values = generate_sparse_vector(FAILING_CRITERION)
+        assert len(indices) == len(set(indices)), "indices must be unique (Qdrant 422 guard)"
+        assert len(indices) == len(values)
+        assert _strictly_increasing(indices)
+
+    def test_unique_even_under_forced_collisions(self, monkeypatch):
+        # Shrink the index space so distinct tokens are guaranteed to collide,
+        # making the regression deterministic regardless of PYTHONHASHSEED.
+        monkeypatch.setattr(sync_embeddings, "SPARSE_HASH_MOD", 4)
+        indices, values = generate_sparse_vector(FAILING_CRITERION)
+        assert indices == sorted(set(indices))
+        assert len(indices) == len(values)
+        assert all(v > 0 for v in values)
+        # No term-frequency mass is lost when colliding indices are merged.
+        raw_tokens = re.findall(r"\b[a-z0-9]{2,}\b", FAILING_CRITERION.lower())
+        assert sum(values) == float(len(raw_tokens))
+
+    def test_result_is_valid_qdrant_sparse_vector(self):
+        from qdrant_client.models import SparseVector
+
+        indices, values = generate_sparse_vector(FAILING_CRITERION)
+        sv = SparseVector(indices=indices, values=values)
+        assert len(sv.indices) == len(set(sv.indices))
+        assert len(sv.indices) == len(sv.values)
+
+    def test_empty_text_returns_empty(self):
+        assert generate_sparse_vector("") == ([], [])
+        assert generate_sparse_vector("   !!!  ") == ([], [])

--- a/vendor/kbase/vector/sync_embeddings.py
+++ b/vendor/kbase/vector/sync_embeddings.py
@@ -186,6 +186,38 @@ def generate_embeddings_batch(
     return all_embeddings
 
 
+# Sparse-vector index space. Token hashes are taken mod this value.
+SPARSE_HASH_MOD = 2**20  # ~1M possible indices
+
+
+def dedupe_sparse(
+    indices: List[int], values: List[float]
+) -> tuple[List[int], List[float]]:
+    """
+    Collapse duplicate sparse-vector indices, aggregating their values.
+
+    Qdrant rejects a SparseVector whose indices are not unique
+    (422: "indices: must be unique"). Distinct tokens can map to the same
+    index via hash collision (mod SPARSE_HASH_MOD), so any sparse vector
+    must be deduped before upsert/query. Colliding indices have their
+    values summed; the result is sorted by index for determinism.
+
+    Args:
+        indices: Sparse vector indices (may contain duplicates)
+        values: Parallel list of values
+
+    Returns:
+        (indices, values) with unique, ascending indices
+    """
+    from collections import defaultdict
+
+    agg: dict = defaultdict(float)
+    for i, v in zip(indices, values):
+        agg[i] += v
+    items = sorted(agg.items())
+    return [i for i, _ in items], [v for _, v in items]
+
+
 def generate_sparse_vector(text: str) -> tuple[List[int], List[float]]:
     """
     Generate a sparse vector for BM25-style keyword search.
@@ -197,7 +229,8 @@ def generate_sparse_vector(text: str) -> tuple[List[int], List[float]]:
         text: Text to convert to sparse vector
 
     Returns:
-        Tuple of (indices, values) for sparse vector
+        Tuple of (indices, values) for sparse vector. Indices are unique
+        and ascending (deduped against hash collisions).
     """
     import re
     from collections import Counter
@@ -211,20 +244,18 @@ def generate_sparse_vector(text: str) -> tuple[List[int], List[float]]:
     # Count term frequencies
     term_counts = Counter(tokens)
 
-    # Convert to sparse vector format
-    # Use hash of token as index (mod large prime for reasonable index range)
-    HASH_MOD = 2**20  # ~1M possible indices
-
     indices = []
     values = []
 
     for token, count in term_counts.items():
         # Use hash of token as index
-        token_hash = hash(token) % HASH_MOD
+        token_hash = hash(token) % SPARSE_HASH_MOD
         indices.append(token_hash)
         values.append(float(count))
 
-    return indices, values
+    # Distinct tokens can collide onto the same index mod SPARSE_HASH_MOD.
+    # Qdrant requires unique indices, so dedupe before returning.
+    return dedupe_sparse(indices, values)
 
 
 def generate_sparse_vectors_batch(texts: List[str]) -> List[tuple[List[int], List[float]]]:

--- a/vendor/kbase/vector/sync_indexing.py
+++ b/vendor/kbase/vector/sync_indexing.py
@@ -666,15 +666,26 @@ def ensure_collection(
                 mode="dense only",
             )
 
-        # Create payload indexes for filterable fields
+        # Create payload indexes for every field any tool filters on. Qdrant
+        # raises HTTP 400 ("Index required but not found") on a filter against
+        # an unindexed field, so index the full superset across all collection
+        # types up front. Indexing a field absent from a given collection is a
+        # cheap no-op, so over-indexing here is harmless.
         from qdrant_client.models import PayloadSchemaType
-        for field in ("language", "domain", "doc_type", "name", "channel", "client_id"):
+        index_fields = (
+            "language", "domain", "doc_type", "name", "channel", "client_id",
+            # rubrics / templates filter fields
+            "framework", "section", "rubric_section", "entry_type",
+            # contributions (moderation queue) filter fields
+            "status", "target_collection", "contributed_by", "contribution_id",
+        )
+        for field in index_fields:
             client.create_payload_index(
                 collection_name=collection_name,
                 field_name=field,
                 field_schema=PayloadSchemaType.KEYWORD,
             )
-        logger.info("Payload indexes created", collection=collection_name)
+        logger.info("Payload indexes created", collection=collection_name, count=len(index_fields))
 
         return True
 


### PR DESCRIPTION
Two fixes stranded on this branch after #25 squash-merged only the qdrant commit. Brings them into main.

## 1. Admin status from X-Is-Admin header (gateway mode) — 8ce2416

Gateway-routed mode sends the shared upstream API key in Authorization, not the caller token, so introspecting it never yields the caller admin flag. The gateway (oauth-server #94, merged) now resolves `users.is_admin` and forwards `X-Is-Admin`. `BearerAuthMiddleware` reads it into the `current_is_admin` ContextVar.

Without this, every admin-only write (`manage_contributions action=review`, `add_rubric_criterion`, `add_template`, `add_thesaurus_entry`) returns `Admin access required` in production. Verified live: the header is forwarded but the deployed build ignores it.

Tests: `tests/test_admin_header.py` — header true/false/absent, ContextVar reset.

## 2. Collapse chunk-twin points in queue list + review — c533631

A contribution is indexed as one Qdrant point per content chunk, so multi-chunk entries are stored as several points sharing one `contribution_id` (byte-identical payloads). Treating point == entry caused:

- `list_contributions` returned one row per point — 139 rows for 94 logical contributions. Now pages all points, collapses by `contribution_id`, bounds `limit` to logical entries.
- `review_contribution` scrolled `limit=1` and flipped one point, leaving the twin stuck `pending` so it resurfaced. Now pages all points for the id, `set_payload` flips every twin in one call, `_publish_to_shared` runs exactly once.

Tests: `tests/test_contributions_dedup.py` — collapse, distinct-id retention, limit bounding, flip-all/publish-once, already-reviewed guard, not-found.

## Deploy gate

After merge + Railway redeploy, admin approval of the 94 pending rubrics also needs `ADMIN_CLIENT_ID` set in writing-library env and the caller `users.is_admin=true` in the gateway DB.
