### PR TITLE
fix(vector): make sparse BM25 encoder deterministic across processes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,15 @@ QDRANT_API_KEY=
 OPENAI_API_KEY=your_openai_api_key_here
 EMBEDDING_MODEL=text-embedding-3-small
 
+# Sparse (BM25) encoder for hybrid search — see docs/sparse-encoder-fix-runbook.md
+# Path to the fitted BM25 encoder artifact (produced by scripts/train_bm25_encoder.py).
+# When present, the sparse arm uses the fitted vocab; otherwise it falls back to a
+# deterministic md5-hashed encoder. Both are deterministic across processes.
+BM25_ENCODER_PATH=.data/bm25_encoder.pkl
+# Set to 1 in production to refuse the md5 fallback and fail loudly if the fitted
+# artifact is missing (prevents silent index/query encoder drift after a deploy).
+BM25_REQUIRE_FITTED=0
+
 # Collection Names
 COLLECTION_PASSAGES=writing_passages
 COLLECTION_TERMS=writing_terms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Fixed
+
+- **Sparse (BM25) hybrid-search arm was silently dead in production.**
+  `generate_sparse_vector` derived indices from the builtin `hash(token)`, which
+  CPython salts per process (`PYTHONHASHSEED`). Indices produced at index time
+  never matched indices produced at query time in another process, so the stored
+  sparse vectors were unreproducible and the sparse arm returned effectively
+  nothing — hybrid search collapsed to dense-only. `generate_sparse_vector` now
+  delegates to a deterministic encoder (fitted BM25 vocab when a
+  `BM25_ENCODER_PATH` artifact is present, else a deterministic md5 fallback);
+  index and query share the one function. Requires a full sparse re-index of
+  every writing collection — see `docs/sparse-encoder-fix-runbook.md`.
+
+### Added
+
+- `scripts/train_bm25_encoder.py` — fit one shared BM25 encoder over all writing
+  collections; `scripts/reindex_sparse.py` — regenerate only the `sparse` named
+  vector per point (dense/payload untouched); `scripts/which_encoder.py` —
+  diagnose stored-vector reproducibility and text-query self-rank.
+- `BM25_ENCODER_PATH` / `BM25_REQUIRE_FITTED` env vars (see `.env.example`).
+
 ## [1.8.0] - 2026-05-22
 
 ### Added

--- a/docs/sparse-encoder-fix-runbook.md
+++ b/docs/sparse-encoder-fix-runbook.md
@@ -1,0 +1,137 @@
+# Runbook: deterministic sparse encoder + full sparse re-index
+
+## What was broken
+
+The sparse (keyword / BM25) arm of hybrid search derived its indices from
+Python's builtin `hash(token)`:
+
+```python
+# vendor/kbase/vector/sync_embeddings.py (old)
+token_hash = hash(token) % SPARSE_HASH_MOD   # SPARSE_HASH_MOD = 2**20
+```
+
+CPython **salts `hash(str)` per process** via `PYTHONHASHSEED`. So the indices
+computed when a document was **indexed** (one process) and the indices computed
+for the same terms at **query** time (a different process) never agreed. The
+query sparse vector's nonzero indices essentially never lined up with the stored
+ones.
+
+Both live paths used this exact function:
+
+- index: `sync_indexing.py` → `generate_sparse_vectors_batch`
+- query: `sync_search.py` → `generate_sparse_vector`
+
+Every MCP tool searches through `sync_search.semantic_search`, so **the deployed
+Qdrant hybrid sparse arm has effectively been returning empty on real queries —
+hybrid silently collapsed to dense-only in production.** A diagnostic
+(`scripts/which_encoder.py`) measured 0% index-set overlap between stored sparse
+vectors and every encoder in the codebase, across `PYTHONHASHSEED` 0/1/42.
+
+The stored sparse vectors are therefore **unreproducible garbage** and must be
+regenerated. Dense vectors were always fine.
+
+## The fix (code)
+
+`generate_sparse_vector` is now deterministic. It delegates to
+`hybrid_embeddings.get_sparse_embedding`, which uses:
+
+1. a **fitted BM25 vocab encoder** when an artifact is present
+   (`BM25_ENCODER_PATH`, default `.data/bm25_encoder.pkl`), else
+2. a **deterministic md5-hashed TF fallback** (same 2**20 index space).
+
+Both index and query call the one function, so both use the identical encoder
+and their indices reproducibly align across processes. `dedupe_sparse` still
+guards the Qdrant "indices must be unique" 422.
+
+Two env vars (see `.env.example`):
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `BM25_ENCODER_PATH` | `.data/bm25_encoder.pkl` | Fitted encoder artifact location. |
+| `BM25_REQUIRE_FITTED` | `0` | If `1`, refuse the md5 fallback and raise if the artifact is missing — prevents silent index/query encoder drift across a deploy. Set to `1` in production. |
+
+## Why a re-index is mandatory
+
+The encoder identity that produced the **stored** vectors must match the encoder
+used at **query** time. Existing stored vectors came from the broken builtin-hash
+encoder, so every writing collection must be re-indexed with the new encoder.
+Only the `sparse` named vector is regenerated; dense vectors and payloads are
+left untouched.
+
+> ⚠️ **Ordering matters.** The md5 fallback and a fitted encoder occupy
+> *different* index spaces. If you index with one and query with the other you
+> reproduce the same "sparse arm returns nothing" outage. Deploy the SAME encoder
+> everywhere, re-index, then serve queries.
+
+## Procedure (Qdrant)
+
+Chosen encoder: **fitted BM25** (per Danilo). Run from the repo root with the
+target Qdrant env (`QDRANT_URL`, `QDRANT_API_KEY`) configured.
+
+1. **Fit the shared encoder** over the union of every writing collection. A
+   single shared vocab keeps cross-collection / cross-tenant sparse search
+   coherent — do not fit per collection.
+   ```bash
+   uv run python scripts/train_bm25_encoder.py --output .data/bm25_encoder.pkl
+   ```
+   The script asserts `vocab_size <= 2**20` so the artifact fits both Qdrant and
+   the Postgres `sparsevec(1048576)` mirror.
+
+2. **Deploy the artifact to every writing-library instance** at the same
+   `BM25_ENCODER_PATH` (e.g. bake into the image or mount on a Railway volume),
+   and set `BM25_REQUIRE_FITTED=1`. Every instance must serve queries with the
+   exact same `.pkl`.
+
+3. **Re-index the sparse vectors** (idempotent; `--dry-run` first to preview):
+   ```bash
+   uv run python scripts/reindex_sparse.py --dry-run
+   uv run python scripts/reindex_sparse.py
+   ```
+   This recomputes only the `sparse` named vector per point via
+   `update_vectors` — dense + payload are preserved, no dense re-embed.
+
+4. **Verify**:
+   ```bash
+   uv run python scripts/which_encoder.py
+   ```
+   Expected after re-index:
+   - **self-consistency recall ≈ 100%** (stored ∩ recomputed / stored), vs ~0%
+     before;
+   - **text-query self-rank**: non-empty sparse arm and source passages
+     `hit@10 ≈ 100%` on their own text.
+
+   Exit code is non-zero if either check fails.
+
+## Procedure (Postgres / pgvector mirror — Track-B)
+
+Track-B migrated Danilo's tenant (`usr_93f07c15894b4877`) into the dsmoz-intel
+Postgres project (`bwbghsnnrszdcmwqzjwv`), tables `writing_passages` etc., with a
+`sparse_embedding sparsevec(1048576)` column. The migration **copied the same
+garbage sparse data**, so the pg column must be regenerated with the identical
+fitted encoder. The pg adapter (`pgvector_adapter.py`, in the Track-B migration
+work) stores indices **1-based** and shifts query indices **+1**.
+
+Regenerate the pg sparse column the same way:
+
+1. Use the **same** `.data/bm25_encoder.pkl` fitted above (do not re-fit — the
+   vocab index space must match Qdrant).
+2. For each row, recompute `generate_sparse_vector(text)` on the row's stored
+   text, then write `sparse_embedding` as a `sparsevec(1048576)` literal, applying
+   the adapter's **+1** index shift (0-based encoder index `i` → pg index `i+1`;
+   this is why the fit guard is `vocab_size <= 2**20`, keeping the shifted max
+   `≤ 1048576`).
+3. Verify a stored-vector self-query and a text-query on the pg side ranks the
+   source passage highly, mirroring the Qdrant `which_encoder.py` checks.
+
+> This repo does not contain `pgvector_adapter.py` or DB credentials; run the pg
+> regeneration from the Track-B migration workspace with dsmoz-intel access, or
+> hand it back to whoever owns that environment. The encoder artifact and
+> `generate_sparse_vector` are the shared, authoritative pieces.
+
+## Rollback
+
+The change is additive and deterministic. To revert the *code* you would restore
+the builtin-hash encoder, but that reintroduces the outage — don't. If a re-index
+must be undone, dense search is unaffected throughout; the sparse arm simply
+returns to its prior (broken) state. There is no destructive data step: dense
+vectors and payloads are never modified.

--- a/scripts/_sparse_ops.py
+++ b/scripts/_sparse_ops.py
@@ -1,0 +1,129 @@
+"""
+Shared helpers for the sparse-encoder maintenance scripts.
+
+These back three operational scripts that together recover from the builtin-
+``hash()`` sparse-encoder bug (see ``docs/sparse-encoder-fix-runbook.md``):
+
+    train_bm25_encoder.py   — fit ONE shared BM25 vocab over every writing
+                              collection and save the artifact.
+    reindex_sparse.py       — regenerate only the "sparse" named vector of
+                              every stored point with the deterministic encoder.
+    which_encoder.py        — diagnose whether stored sparse vectors are
+                              reproducible by the current encoder.
+
+Keeping the Qdrant plumbing in one place means the fit corpus, the reindex
+corpus and the diagnostic all agree on which collections and which text field
+matter.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional
+
+
+def bootstrap() -> Path:
+    """Mirror ``main.py``: make the project root + vendored ``kbase`` importable
+    and load ``.env``. Returns the project root."""
+    root = Path(__file__).resolve().parent.parent
+    for p in (root, root / "vendor"):
+        if p.exists() and str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(root / ".env")
+    except Exception:
+        # dotenv is optional; env vars may already be set (e.g. in Railway).
+        pass
+    return root
+
+
+# Default artifact location, matched to hybrid_embeddings.get_sparse_embedding
+# and BM25_ENCODER_PATH.
+DEFAULT_ENCODER_PATH = os.getenv("BM25_ENCODER_PATH") or os.path.join(
+    ".data", "bm25_encoder.pkl"
+)
+
+# Per-user collection suffixes (see src/tools/collections.py) + shared/core ones.
+_WRITING_SUFFIXES = (
+    "_writing_passages",
+    "_writing_terms",
+    "_writing_style_profiles",
+    "_writing_rubrics",
+    "_writing_templates",
+    "_writing_thesaurus",
+)
+_CORE_COLLECTIONS = ("writing_terms_shared", "writing_contributions")
+
+
+def is_writing_collection(name: str) -> bool:
+    """True if ``name`` is one of the writing library's collections."""
+    return name in _CORE_COLLECTIONS or any(
+        name.endswith(suffix) for suffix in _WRITING_SUFFIXES
+    )
+
+
+def collection_is_hybrid(client, name: str) -> bool:
+    """True if the collection has a named ``sparse`` sparse-vector config."""
+    info = client.get_collection(collection_name=name)
+    sparse_conf = getattr(info.config.params, "sparse_vectors", None)
+    return bool(sparse_conf) and "sparse" in sparse_conf
+
+
+def list_hybrid_writing_collections(
+    client, only: Optional[Iterable[str]] = None
+) -> List[str]:
+    """Return the sorted names of hybrid writing collections.
+
+    Args:
+        client: Qdrant client.
+        only: If given, restrict to this explicit set of names (still filtered
+            to those that are actually hybrid). If None, auto-discover every
+            writing collection.
+    """
+    only_set = set(only) if only is not None else None
+    all_names = [c.name for c in client.get_collections().collections]
+    result: List[str] = []
+    for name in sorted(all_names):
+        if only_set is not None:
+            if name not in only_set:
+                continue
+        elif not is_writing_collection(name):
+            continue
+        try:
+            if collection_is_hybrid(client, name):
+                result.append(name)
+        except Exception:
+            # A collection that vanished or can't be described is simply skipped.
+            continue
+    return result
+
+
+def scroll_points(
+    client,
+    collection: str,
+    with_vectors: bool = False,
+    batch: int = 256,
+) -> Iterator:
+    """Yield every point in ``collection`` (payload always, vectors optional)."""
+    offset = None
+    while True:
+        points, offset = client.scroll(
+            collection_name=collection,
+            limit=batch,
+            offset=offset,
+            with_payload=True,
+            with_vectors=with_vectors,
+        )
+        for point in points:
+            yield point
+        if offset is None:
+            break
+
+
+def point_text(point) -> str:
+    """The searchable text a point was indexed from (payload['text'])."""
+    payload = getattr(point, "payload", None) or {}
+    return (payload.get("text") or "").strip()

--- a/scripts/reindex_sparse.py
+++ b/scripts/reindex_sparse.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Regenerate stored sparse vectors with the deterministic encoder.
+
+Every sparse vector currently stored in Qdrant was produced by the old builtin-
+``hash()`` encoder and is unreproducible garbage (see
+docs/sparse-encoder-fix-runbook.md). This script recomputes each point's
+"sparse" named vector from its own ``payload['text']`` using the fixed,
+deterministic ``generate_sparse_vector`` and writes it back.
+
+Only the sparse vector is touched — the dense vector and the payload are left
+exactly as they are (``update_vectors`` updates named vectors in place). A full,
+expensive dense re-embed is NOT required; dense vectors were always fine.
+
+Prerequisite: the fitted BM25 artifact must already be deployed here (same file
+that every instance will serve queries with). Run this AFTER
+scripts/train_bm25_encoder.py and BEFORE serving fitted-encoder queries.
+
+Usage
+-----
+    uv run python scripts/reindex_sparse.py --dry-run       # count only, no writes
+    uv run python scripts/reindex_sparse.py                 # reindex all collections
+    uv run python scripts/reindex_sparse.py --collections usr_abc_writing_passages
+"""
+import argparse
+import sys
+
+from _sparse_ops import (
+    bootstrap,
+    list_hybrid_writing_collections,
+    point_text,
+    scroll_points,
+)
+
+
+def main() -> int:
+    bootstrap()
+
+    parser = argparse.ArgumentParser(
+        description="Regenerate stored sparse vectors deterministically."
+    )
+    parser.add_argument("--collections", nargs="*", default=None,
+                        help="Explicit collections (default: all hybrid writing collections).")
+    parser.add_argument("--batch", type=int, default=256, help="Upsert batch size.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Compute and report, but write nothing.")
+    args = parser.parse_args()
+
+    from qdrant_client import models
+
+    from kbase.vector.sync_client import get_qdrant_client
+    from kbase.vector.sync_embeddings import generate_sparse_vector
+    from kbase.vector.bm25_encoder import get_bm25_encoder
+
+    client = get_qdrant_client()
+
+    # Announce which encoder is active so an accidental md5-fallback reindex is
+    # visible rather than silent.
+    if get_bm25_encoder() is not None:
+        print("Encoder: FITTED BM25 vocab", file=sys.stderr)
+    else:
+        print(
+            "Encoder: md5 deterministic FALLBACK (no fitted artifact found). "
+            "This is deterministic and correct, but lower quality than a fitted "
+            "encoder and lives in a different index space — make sure queries "
+            "will use the SAME encoder.",
+            file=sys.stderr,
+        )
+
+    collections = list_hybrid_writing_collections(client, only=args.collections)
+    if not collections:
+        print("No hybrid writing collections found; nothing to reindex.", file=sys.stderr)
+        return 1
+
+    grand_updated = grand_skipped = 0
+    for name in collections:
+        updated = skipped = 0
+        buffer: list = []
+
+        def flush():
+            nonlocal updated
+            if not buffer:
+                return
+            if not args.dry_run:
+                client.update_vectors(collection_name=name, points=list(buffer))
+            updated += len(buffer)
+            buffer.clear()
+
+        for point in scroll_points(client, name, with_vectors=False, batch=args.batch):
+            indices, values = generate_sparse_vector(point_text(point))
+            if not indices:
+                # No usable tokens — an empty sparse vector contributes nothing;
+                # leave whatever is there rather than pushing an empty vector.
+                skipped += 1
+                continue
+            buffer.append(
+                models.PointVectors(
+                    id=point.id,
+                    vector={"sparse": models.SparseVector(indices=indices, values=values)},
+                )
+            )
+            if len(buffer) >= args.batch:
+                flush()
+        flush()
+
+        verb = "would update" if args.dry_run else "updated"
+        print(f"  {name}: {verb} {updated} points ({skipped} skipped, empty text)",
+              file=sys.stderr)
+        grand_updated += updated
+        grand_skipped += skipped
+
+    verb = "Would update" if args.dry_run else "Updated"
+    print(f"\n{verb} {grand_updated} sparse vectors across {len(collections)} "
+          f"collection(s); {grand_skipped} skipped.", file=sys.stderr)
+    if args.dry_run:
+        print("Dry run — nothing was written.", file=sys.stderr)
+    else:
+        print("Verify with: uv run python scripts/which_encoder.py", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/train_bm25_encoder.py
+++ b/scripts/train_bm25_encoder.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Fit the shared BM25 sparse encoder.
+
+Why this exists
+---------------
+The sparse (keyword) arm of hybrid search used to derive its indices from
+Python's builtin ``hash()``, which is salted per process (PYTHONHASHSEED). Index-
+time and query-time indices therefore never agreed and hybrid search silently
+collapsed to dense-only. The fix makes ``generate_sparse_vector`` deterministic,
+preferring a *fitted* BM25 vocab encoder when this artifact is present.
+
+This script fits ONE encoder over the union of every writing collection's text.
+A single shared vocabulary (identical index space on every server) is what keeps
+cross-collection / cross-tenant sparse search coherent — do not fit a separate
+encoder per collection.
+
+Usage
+-----
+    uv run python scripts/train_bm25_encoder.py
+    uv run python scripts/train_bm25_encoder.py --output .data/bm25_encoder.pkl
+    uv run python scripts/train_bm25_encoder.py --collections usr_abc_writing_passages writing_terms_shared
+
+After fitting, deploy the artifact to EVERY writing-library instance (same file),
+then run scripts/reindex_sparse.py before serving queries. See
+docs/sparse-encoder-fix-runbook.md.
+"""
+import argparse
+import sys
+
+from _sparse_ops import (
+    DEFAULT_ENCODER_PATH,
+    bootstrap,
+    list_hybrid_writing_collections,
+    point_text,
+    scroll_points,
+)
+
+# pgvector mirror stores sparse_embedding as sparsevec(1048576) and the adapter
+# shifts indices +1 (1-based), so the largest 0-based vocab index must stay
+# strictly below this. A fitted vocab is sequential [0, vocab_size), so the
+# guard is simply vocab_size <= SPARSE_DIM.
+SPARSE_DIM = 2**20  # 1_048_576
+
+
+def main() -> int:
+    root = bootstrap()
+
+    parser = argparse.ArgumentParser(description="Fit the shared BM25 sparse encoder.")
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=DEFAULT_ENCODER_PATH,
+        help=f"Where to write the encoder (default: {DEFAULT_ENCODER_PATH})",
+    )
+    parser.add_argument(
+        "--collections",
+        nargs="*",
+        default=None,
+        help="Explicit collection names to fit on (default: auto-discover all "
+        "hybrid writing collections).",
+    )
+    parser.add_argument(
+        "--min-docs",
+        type=int,
+        default=1,
+        help="Refuse to fit if fewer than this many documents were collected.",
+    )
+    args = parser.parse_args()
+
+    from kbase.vector.sync_client import get_qdrant_client
+    from kbase.vector.bm25_encoder import BM25Encoder
+
+    client = get_qdrant_client()
+
+    collections = list_hybrid_writing_collections(client, only=args.collections)
+    if not collections:
+        print("No hybrid writing collections found; nothing to fit.", file=sys.stderr)
+        return 1
+
+    print(f"Fitting shared BM25 encoder over {len(collections)} collection(s):", file=sys.stderr)
+    documents = []
+    for name in collections:
+        count = 0
+        for point in scroll_points(client, name, with_vectors=False):
+            text = point_text(point)
+            if text:
+                documents.append(text)
+                count += 1
+        print(f"  {name}: {count} documents", file=sys.stderr)
+
+    if len(documents) < args.min_docs:
+        print(
+            f"Collected only {len(documents)} documents (< --min-docs "
+            f"{args.min_docs}); refusing to fit a degenerate encoder.",
+            file=sys.stderr,
+        )
+        return 1
+
+    encoder = BM25Encoder()
+    encoder.fit(documents, verbose=True)
+
+    vocab_size = len(encoder.vocab_to_index)
+    if vocab_size > SPARSE_DIM:
+        print(
+            f"ERROR: fitted vocabulary ({vocab_size}) exceeds the sparse index "
+            f"space ({SPARSE_DIM}). The Qdrant sparse arm and the Postgres "
+            f"sparsevec({SPARSE_DIM}) mirror cannot represent it. Reduce the "
+            "corpus or raise the sparse dimension before proceeding.",
+            file=sys.stderr,
+        )
+        return 1
+
+    encoder.save(args.output)
+
+    stats = encoder.get_stats()
+    print("", file=sys.stderr)
+    print("Fitted BM25 encoder:", file=sys.stderr)
+    print(f"  documents:        {len(documents)}", file=sys.stderr)
+    print(f"  vocabulary size:  {vocab_size} (limit {SPARSE_DIM})", file=sys.stderr)
+    print(f"  avg doc length:   {stats.average_document_length:.1f} tokens", file=sys.stderr)
+    print(f"  saved to:         {args.output}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "Next: deploy this artifact to every instance (BM25_ENCODER_PATH), set "
+        "BM25_REQUIRE_FITTED=1, then run scripts/reindex_sparse.py.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/which_encoder.py
+++ b/scripts/which_encoder.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Diagnose whether stored sparse vectors are reproducible by the current encoder.
+
+Two checks, per collection, over a bounded sample:
+
+  1. STORED-VECTOR SELF-CONSISTENCY
+     Pull each point WITH its stored sparse vector, recompute the sparse vector
+     from the point's OWN ``payload['text']`` with the current deterministic
+     ``generate_sparse_vector``, and measure how well the recomputed nonzero
+     index set overlaps the stored one (recall = |stored ∩ recomputed| / |stored|).
+
+       * With the OLD builtin-hash() data this is ~0% — proof the stored sparse
+         vectors are garbage and a reindex is required.
+       * After scripts/reindex_sparse.py with the SAME encoder, this is ~100%.
+
+  2. TEXT-QUERY SELF-RANK
+     For each sampled point, issue a sparse-only query built from its own text
+     and confirm (a) the sparse arm is NON-EMPTY and (b) the source point ranks
+     highly (ideally #1). This exercises the exact query path used by
+     sync_search's hybrid prefetch.
+
+Usage
+-----
+    uv run python scripts/which_encoder.py
+    uv run python scripts/which_encoder.py --collections usr_abc_writing_passages --sample 300
+"""
+import argparse
+import statistics
+import sys
+
+from _sparse_ops import (
+    bootstrap,
+    list_hybrid_writing_collections,
+    point_text,
+    scroll_points,
+)
+
+
+def _stored_sparse_indices(point) -> set:
+    """Extract the stored 'sparse' vector's index set from a scrolled point,
+    tolerating both object and dict representations."""
+    vec = getattr(point, "vector", None)
+    if not isinstance(vec, dict):
+        return set()
+    sparse = vec.get("sparse")
+    if sparse is None:
+        return set()
+    indices = getattr(sparse, "indices", None)
+    if indices is None and isinstance(sparse, dict):
+        indices = sparse.get("indices")
+    return set(int(i) for i in (indices or []))
+
+
+def main() -> int:
+    bootstrap()
+
+    parser = argparse.ArgumentParser(
+        description="Diagnose sparse-vector reproducibility."
+    )
+    parser.add_argument("--collections", nargs="*", default=None,
+                        help="Explicit collections (default: all hybrid writing collections).")
+    parser.add_argument("--sample", type=int, default=200,
+                        help="Max points to sample per collection (default: 200).")
+    parser.add_argument("--topk", type=int, default=10,
+                        help="Top-k for the text-query self-rank test (default: 10).")
+    parser.add_argument("--no-query-test", action="store_true",
+                        help="Skip the text-query self-rank test (self-consistency only).")
+    args = parser.parse_args()
+
+    from qdrant_client import models
+
+    from kbase.vector.sync_client import get_qdrant_client
+    from kbase.vector.sync_embeddings import generate_sparse_vector
+    from kbase.vector.bm25_encoder import get_bm25_encoder
+
+    client = get_qdrant_client()
+
+    print("Active encoder:",
+          "FITTED BM25 vocab" if get_bm25_encoder() is not None
+          else "md5 deterministic fallback",
+          file=sys.stderr)
+
+    collections = list_hybrid_writing_collections(client, only=args.collections)
+    if not collections:
+        print("No hybrid writing collections found.", file=sys.stderr)
+        return 1
+
+    overall_ok = True
+    for name in collections:
+        recalls = []
+        empty_recompute = 0
+        sampled = 0
+        sample_points = []
+
+        for point in scroll_points(client, name, with_vectors=True):
+            stored = _stored_sparse_indices(point)
+            text = point_text(point)
+            recomputed_idx, _ = generate_sparse_vector(text)
+            recomputed = set(recomputed_idx)
+            if not recomputed:
+                empty_recompute += 1
+            if stored:
+                inter = len(stored & recomputed)
+                recalls.append(inter / len(stored))
+            sample_points.append((point.id, text))
+            sampled += 1
+            if sampled >= args.sample:
+                break
+
+        if not sampled:
+            print(f"  {name}: empty collection, skipped", file=sys.stderr)
+            continue
+
+        mean_recall = statistics.mean(recalls) if recalls else float("nan")
+        print(f"\n[{name}] sampled {sampled} points", file=sys.stderr)
+        print(f"  self-consistency recall (stored ∩ recomputed / stored): "
+              f"{mean_recall:.1%}" if recalls else
+              "  self-consistency recall: n/a (no stored sparse vectors)",
+              file=sys.stderr)
+        print(f"  points whose text recomputes to an EMPTY sparse vector: "
+              f"{empty_recompute}/{sampled}", file=sys.stderr)
+        if recalls and mean_recall < 0.99:
+            overall_ok = False
+            print("  ⚠️  stored sparse vectors are NOT reproducible by the "
+                  "current encoder — run scripts/reindex_sparse.py.", file=sys.stderr)
+
+        if args.no_query_test:
+            continue
+
+        # Text-query self-rank: does a sparse-only query from a point's own text
+        # surface that point?
+        hits_at_1 = hits_at_k = nonempty = considered = 0
+        ranks = []
+        for pid, text in sample_points[: min(50, len(sample_points))]:
+            indices, values = generate_sparse_vector(text)
+            if not indices:
+                continue
+            nonempty += 1
+            considered += 1
+            res = client.query_points(
+                collection_name=name,
+                query=models.SparseVector(indices=indices, values=values),
+                using="sparse",
+                limit=args.topk,
+                with_payload=False,
+            ).points
+            ids = [p.id for p in res]
+            if ids and ids[0] == pid:
+                hits_at_1 += 1
+            if pid in ids:
+                hits_at_k += 1
+                ranks.append(ids.index(pid) + 1)
+        if considered:
+            print(f"  text-query self-rank over {considered} points: "
+                  f"hit@1={hits_at_1/considered:.1%}, "
+                  f"hit@{args.topk}={hits_at_k/considered:.1%}, "
+                  f"median rank={statistics.median(ranks) if ranks else 'n/a'}, "
+                  f"non-empty sparse arm={nonempty}/{considered}", file=sys.stderr)
+            if hits_at_k / considered < 0.9:
+                overall_ok = False
+                print("  ⚠️  source passages do not rank in top-k on their own "
+                      "text — sparse arm is not working as expected.", file=sys.stderr)
+        else:
+            print("  text-query self-rank: no non-empty sparse queries to test.",
+                  file=sys.stderr)
+
+    print("\nRESULT:", "OK — sparse vectors are reproducible and self-queries rank."
+          if overall_ok else
+          "PROBLEM — see warnings above (reindex needed or encoder mismatch).",
+          file=sys.stderr)
+    return 0 if overall_ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sparse_dedupe.py
+++ b/tests/test_sparse_dedupe.py
@@ -1,19 +1,32 @@
 """
-Regression tests for sparse-vector index deduplication.
+Tests for the sparse-vector encoder.
 
-Bug: admin_add / contribute upserts intermittently failed with Qdrant 422
-"[points[0].vector.?.indices: must be unique]". Root cause: distinct tokens
-collided onto the same index via ``hash(token) % SPARSE_HASH_MOD`` in
-generate_sparse_vector(); the salted hash() made it content- and run-dependent.
-Fix: dedupe_sparse() collapses colliding indices and sums their values before
-the sparse vector is returned (covering every collection that upserts).
+Two bugs are guarded here:
 
-The criterion text below is the exact string that failed twice in production
-before succeeding on a shorter rephrase.
+1. Qdrant 422 "[indices: must be unique]" — distinct tokens can collide onto the
+   same sparse index, and Qdrant rejects a SparseVector with duplicate indices.
+   dedupe_sparse() collapses colliding indices (summing their values) before the
+   vector is returned.
+
+2. Non-deterministic indices (the big one) — generate_sparse_vector() used to
+   derive indices from the builtin ``hash(token)``, which CPython salts per
+   process (PYTHONHASHSEED). Indices produced when a document was *indexed*
+   therefore never matched the indices produced for the same terms at *query*
+   time in a different process, so the hybrid sparse arm returned nothing and
+   hybrid search silently collapsed to dense-only. The encoder is now
+   deterministic (a fitted BM25 vocab when an artifact is present, else a
+   deterministic md5-hashed TF fallback).
 """
-import re
+import hashlib
+import math
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
 
-from kbase.vector import sync_embeddings
+import pytest
+
 from kbase.vector.sync_embeddings import dedupe_sparse, generate_sparse_vector
 
 FAILING_CRITERION = (
@@ -22,9 +35,22 @@ FAILING_CRITERION = (
     "government), traceable to dialogue findings."
 )
 
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
 
 def _strictly_increasing(xs) -> bool:
     return all(a < b for a, b in zip(xs, xs[1:]))
+
+
+@pytest.fixture()
+def _reset_bm25_cache():
+    """Reset the global BM25 encoder cache around a test that loads an artifact,
+    so it does not leak into tests that expect the md5 fallback."""
+    import kbase.vector.bm25_encoder as be
+
+    yield
+    be._bm25_encoder = None
+    be._encoder_path = None
 
 
 class TestDedupeSparse:
@@ -54,17 +80,22 @@ class TestGenerateSparseVector:
         assert len(indices) == len(values)
         assert _strictly_increasing(indices)
 
-    def test_unique_even_under_forced_collisions(self, monkeypatch):
-        # Shrink the index space so distinct tokens are guaranteed to collide,
-        # making the regression deterministic regardless of PYTHONHASHSEED.
-        monkeypatch.setattr(sync_embeddings, "SPARSE_HASH_MOD", 4)
-        indices, values = generate_sparse_vector(FAILING_CRITERION)
-        assert indices == sorted(set(indices))
-        assert len(indices) == len(values)
-        assert all(v > 0 for v in values)
-        # No term-frequency mass is lost when colliding indices are merged.
-        raw_tokens = re.findall(r"\b[a-z0-9]{2,}\b", FAILING_CRITERION.lower())
-        assert sum(values) == float(len(raw_tokens))
+    def test_deduped_even_when_encoder_yields_collisions(self, monkeypatch):
+        # generate_sparse_vector delegates to hybrid_embeddings.get_sparse_embedding;
+        # force it to return duplicate indices and confirm the Qdrant-422 dedupe
+        # guard still collapses them (summing values) after the refactor.
+        from qdrant_client.models import SparseVector
+
+        def fake_get_sparse_embedding(text, encoder_path=None):
+            return SparseVector(indices=[7, 3, 7, 3, 7], values=[1.0, 2.0, 1.0, 2.0, 1.0])
+
+        monkeypatch.setattr(
+            "kbase.vector.hybrid_embeddings.get_sparse_embedding",
+            fake_get_sparse_embedding,
+        )
+        indices, values = generate_sparse_vector("anything")
+        assert indices == [3, 7]
+        assert values == [4.0, 3.0]  # index 3: 2+2, index 7: 1+1+1
 
     def test_result_is_valid_qdrant_sparse_vector(self):
         from qdrant_client.models import SparseVector
@@ -74,6 +105,79 @@ class TestGenerateSparseVector:
         assert len(sv.indices) == len(set(sv.indices))
         assert len(sv.indices) == len(sv.values)
 
+    def test_indices_within_sparse_dimension(self):
+        # Every index must fit the Postgres sparsevec(1048576) mirror (and the
+        # +1 shift the adapter applies), i.e. stay strictly below 2**20.
+        indices, _ = generate_sparse_vector(FAILING_CRITERION)
+        assert all(0 <= i < 2**20 for i in indices)
+
     def test_empty_text_returns_empty(self):
         assert generate_sparse_vector("") == ([], [])
         assert generate_sparse_vector("   !!!  ") == ([], [])
+
+
+class TestDeterminism:
+    """The core regression: identical input -> identical indices, regardless of
+    process or PYTHONHASHSEED."""
+
+    def test_uses_md5_not_builtin_hash(self):
+        # With no fitted artifact, the fallback maps a token via md5 (stable
+        # across processes), NOT builtin hash (salted per process). Pin the
+        # exact index so a regression back to hash() fails loudly.
+        indices, values = generate_sparse_vector("priorities")
+        expected_index = int(hashlib.md5(b"priorities").hexdigest(), 16) % (2**20)
+        assert indices == [expected_index]
+        assert values == pytest.approx([math.log(2.0)])  # tf=1 -> 1*log(1+1/1)
+
+    def test_indices_independent_of_pythonhashseed(self):
+        # The real regression: run the encoder in two child processes with
+        # different PYTHONHASHSEED and confirm identical indices. This fails on
+        # the old builtin-hash() encoder and passes on the deterministic one.
+        snippet = (
+            "import sys;"
+            f"sys.path.insert(0, {str(_PROJECT_ROOT)!r});"
+            f"sys.path.insert(0, {str(_PROJECT_ROOT / 'vendor')!r});"
+            "from kbase.vector.sync_embeddings import generate_sparse_vector;"
+            "i,_=generate_sparse_vector('ranked priorities traceable to dialogue findings');"
+            "print(','.join(map(str,i)))"
+        )
+        outs = []
+        for seed in ("0", "1", "42"):
+            env = dict(os.environ, PYTHONHASHSEED=seed)
+            # Ensure the child does not pick up a stray fitted artifact.
+            env.pop("BM25_ENCODER_PATH", None)
+            env.pop("BM25_REQUIRE_FITTED", None)
+            out = subprocess.check_output(
+                [sys.executable, "-c", snippet], env=env, text=True
+            ).strip()
+            outs.append(out)
+        assert outs[0] and outs[0] == outs[1] == outs[2], outs
+
+
+class TestFittedEncoder:
+    """When a fitted BM25 artifact is present, index and query share one vocab,
+    so query indices are a subset of the source document's indices — the exact
+    alignment the builtin-hash bug destroyed."""
+
+    def test_query_indices_subset_of_doc_indices(self, monkeypatch, _reset_bm25_cache):
+        from kbase.vector.bm25_encoder import BM25Encoder
+
+        docs = [
+            "The Global Fund CCM presents ranked priorities traceable to dialogue findings.",
+            "Evidence based recommendation with a responsible actor and specific action.",
+            "Poetry rubric evaluates rhythm meter and imagery in a stanza.",
+        ]
+        encoder = BM25Encoder().fit(docs, verbose=False)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            art = os.path.join(tmp, "bm25_encoder.pkl")
+            encoder.save(art)
+            monkeypatch.setenv("BM25_ENCODER_PATH", art)
+            monkeypatch.setenv("BM25_REQUIRE_FITTED", "1")
+
+            doc_idx, _ = generate_sparse_vector(docs[0])
+            q_idx, _ = generate_sparse_vector("ranked priorities dialogue findings")
+
+            assert q_idx, "query sparse arm must be non-empty"
+            assert set(q_idx).issubset(set(doc_idx))
+            assert all(0 <= i < 2**20 for i in doc_idx + q_idx)

--- a/vendor/kbase/vector/sync_embeddings.py
+++ b/vendor/kbase/vector/sync_embeddings.py
@@ -186,7 +186,10 @@ def generate_embeddings_batch(
     return all_embeddings
 
 
-# Sparse-vector index space. Token hashes are taken mod this value.
+# Sparse-vector index space for the deterministic md5 fallback encoder.
+# Token md5 hashes are taken mod this value. A fitted BM25 encoder, when
+# present, uses its own (sequential) vocab index space instead; both stay
+# within this 2**20 bound so the Postgres ``sparsevec(1048576)`` mirror fits.
 SPARSE_HASH_MOD = 2**20  # ~1M possible indices
 
 
@@ -218,49 +221,92 @@ def dedupe_sparse(
     return [i for i, _ in items], [v for _, v in items]
 
 
+def _require_fitted_encoder() -> bool:
+    """Whether to hard-fail rather than silently use the md5 fallback."""
+    return os.getenv("BM25_REQUIRE_FITTED", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
 def generate_sparse_vector(text: str) -> tuple[List[int], List[float]]:
     """
-    Generate a sparse vector for BM25-style keyword search.
+    Generate a DETERMINISTIC sparse vector for BM25-style keyword search.
 
-    Uses simple tokenization and term frequency counting.
-    The IDF modifier is applied by Qdrant at query time.
+    HISTORY / BUG: this function used to derive indices from the builtin
+    ``hash(token) % SPARSE_HASH_MOD``. CPython salts ``hash(str)`` per process
+    (PYTHONHASHSEED), so the indices produced when a document was *indexed*
+    never matched the indices produced for the same terms at *query* time in a
+    different process. The hybrid sparse arm therefore returned effectively
+    nothing and hybrid search silently collapsed to dense-only in production.
+
+    FIX: delegate to :func:`kbase.vector.hybrid_embeddings.get_sparse_embedding`,
+    which uses a fitted BM25 vocab encoder when an artifact is available
+    (``BM25_ENCODER_PATH`` or the default ``.data/bm25_encoder.pkl``) and a
+    deterministic md5-hashed TF fallback otherwise. Both the index path
+    (:func:`generate_sparse_vectors_batch`) and the query path (``sync_search``)
+    call this one function, so both use the identical deterministic encoder and
+    their indices reproducibly line up across processes.
+
+    See ``docs/sparse-encoder-fix-runbook.md``.
 
     Args:
         text: Text to convert to sparse vector
 
     Returns:
         Tuple of (indices, values) for sparse vector. Indices are unique
-        and ascending (deduped against hash collisions).
+        and ascending (deduped against md5 hash collisions). Empty input
+        (no usable tokens) yields ``([], [])``.
     """
-    import re
-    from collections import Counter
+    # Local imports keep the dependency one-directional (hybrid_embeddings and
+    # bm25_encoder never import this module) and avoid import-time cost for
+    # callers that never touch sparse vectors.
+    from kbase.vector.hybrid_embeddings import get_sparse_embedding
+    from kbase.vector.bm25_encoder import get_bm25_encoder
 
-    # Simple tokenization: lowercase, split on non-alphanumeric, filter short tokens
-    tokens = re.findall(r'\b[a-z0-9]{2,}\b', text.lower())
+    encoder_path = os.getenv("BM25_ENCODER_PATH") or None
 
-    if not tokens:
+    if _require_fitted_encoder() and get_bm25_encoder(encoder_path) is None:
+        raise RuntimeError(
+            "BM25_REQUIRE_FITTED is set but no fitted BM25 encoder was found "
+            f"(BM25_ENCODER_PATH={encoder_path or '.data/bm25_encoder.pkl'}). "
+            "Refusing to fall back to the md5 encoder, which lives in a "
+            "different index space and would silently break hybrid search "
+            "against fitted-encoder data. Deploy the fitted artifact (see the "
+            "runbook) or unset BM25_REQUIRE_FITTED."
+        )
+
+    sv = get_sparse_embedding(text, encoder_path=encoder_path)
+
+    # get_sparse_embedding returns an all-zero sentinel ([0], [0.0]) for text
+    # with no usable tokens. Drop zero-weight entries so empty input yields an
+    # empty vector (historical contract) and no bogus index-0 mass is stored.
+    # Real BM25/TF weights are always strictly positive, so this only strips
+    # the sentinel, never a legitimate term.
+    pairs = [
+        (int(i), float(v))
+        for i, v in zip(sv.indices, sv.values)
+        if float(v) != 0.0
+    ]
+    if not pairs:
         return [], []
 
-    # Count term frequencies
-    term_counts = Counter(tokens)
+    indices = [i for i, _ in pairs]
+    values = [v for _, v in pairs]
 
-    indices = []
-    values = []
-
-    for token, count in term_counts.items():
-        # Use hash of token as index
-        token_hash = hash(token) % SPARSE_HASH_MOD
-        indices.append(token_hash)
-        values.append(float(count))
-
-    # Distinct tokens can collide onto the same index mod SPARSE_HASH_MOD.
-    # Qdrant requires unique indices, so dedupe before returning.
+    # A fitted vocab yields unique indices; the md5 fallback can collide.
+    # Qdrant requires unique indices, so dedupe (and sort) before returning.
     return dedupe_sparse(indices, values)
 
 
 def generate_sparse_vectors_batch(texts: List[str]) -> List[tuple[List[int], List[float]]]:
     """
     Generate sparse vectors for multiple texts.
+
+    Uses the same deterministic encoder as :func:`generate_sparse_vector`, so
+    indexed vectors reproducibly match query vectors across processes.
 
     Args:
         texts: List of texts to convert


### PR DESCRIPTION
## The bug (pre-existing, production)

`vendor/kbase/vector/sync_embeddings.py::generate_sparse_vector` derived sparse indices from the builtin `hash(token) % 2**20`. CPython **salts `hash(str)` per process** (`PYTHONHASHSEED`), so the indices produced when a document was *indexed* never matched the indices produced for the same terms at *query* time in a different process.

Both live paths call this one function — index via `sync_indexing.py` (`generate_sparse_vectors_batch`) and query via `sync_search.py` (`generate_sparse_vector`) — and every MCP tool searches through `sync_search.semantic_search`. So the deployed Qdrant hybrid sparse arm has been effectively returning empty on real queries: **hybrid search silently collapsed to dense-only in production.** A diagnostic measured 0% index-set overlap between stored sparse vectors and every encoder in the codebase, across `PYTHONHASHSEED` 0/1/42.

## The fix

`generate_sparse_vector` now delegates to the deterministic `hybrid_embeddings.get_sparse_embedding`:
- a **fitted BM25 vocab encoder** when a `BM25_ENCODER_PATH` artifact is present (the chosen approach), else
- a deterministic **md5-hashed fallback** in the same `2**20` index space.

Index and query share the one function, so their indices reproducibly align across processes. The `dedupe_sparse` Qdrant-422 uniqueness guard is preserved. Empty input still returns `([], [])`.

New env (see `.env.example`):
- `BM25_ENCODER_PATH` (default `.data/bm25_encoder.pkl`)
- `BM25_REQUIRE_FITTED` — set `1` in prod to refuse the fallback and fail loudly if the artifact is missing, preventing silent index/query encoder drift.

## Operational impact — a full sparse re-index is required

Existing stored sparse vectors are unreproducible garbage and must be regenerated. **Dense vectors are unaffected** (no re-embed). New scripts:

| Script | Purpose |
|--------|---------|
| `scripts/train_bm25_encoder.py` | Fit **one shared** BM25 vocab over all writing collections (asserts `vocab ≤ 2**20` for the pg `sparsevec(1048576)` mirror). |
| `scripts/reindex_sparse.py` | Regenerate **only** the `sparse` named vector per point via `update_vectors` (dense + payload untouched). |
| `scripts/which_encoder.py` | Diagnose stored-vector reproducibility + text-query self-rank. |
| `scripts/_sparse_ops.py` | Shared Qdrant plumbing. |

Full procedure — fit → deploy artifact everywhere → re-index → verify, plus the **dsmoz-intel Postgres `sparsevec` regeneration** (Track-B mirror, +1 index shift) — is in `docs/sparse-encoder-fix-runbook.md`.

## Verification

- Local end-to-end (fitted path): a query's sparse indices are a **subset** of the source doc's indices (the alignment the bug destroyed), non-empty arm, all indices `< 2**20`, deterministic on repeat, and `BM25_REQUIRE_FITTED` raises when the artifact is missing.
- Cross-process determinism confirmed: identical indices under `PYTHONHASHSEED` 0/1/42.
- Tests: `tests/test_sparse_dedupe.py` extended with cross-`PYTHONHASHSEED` determinism, md5-not-builtin-hash pinning, and the fitted-encoder query⊆doc alignment; existing dedupe/422 guards retained. **Full suite: 416 passed.**
- Live Qdrant re-index / verification and the pg regeneration still need to be run against production infra (no DB credentials in CI) — the runbook drives those.

## Notes for reviewers

- The `hybrid_embeddings.py` / `bm25_encoder.py` machinery already existed but was **not wired into the sync path** the tools use; this PR wires the sync path to it rather than adding a parallel encoder.
- Encoder choice (fitted BM25 vs md5 drop-in) was confirmed as **fitted BM25** with the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaEu1N2gUL3iG6GTjFt3S5)_